### PR TITLE
Fix a private-in-public error

### DIFF
--- a/src/mars.rs
+++ b/src/mars.rs
@@ -127,12 +127,12 @@ impl Converter {
 fn wgtochina_lb(wg_flag: i32, wg_lng: i32, wg_lat: i32, wg_heit: i32, _wg_week: i32, wg_time: i32) -> (f64, f64) {
     let mut point: (f64, f64) = (wg_lng as f64, wg_lat as f64);
 
-    let mut x1_x2: f64;
-    let mut y1_y2: f64;
-    let mut casm_v: f64;
+    let x1_x2: f64;
+    let y1_y2: f64;
+    let casm_v: f64;
     let mut x_add: f64;
     let mut y_add: f64;
-    let mut h_add: f64;
+    let h_add: f64;
 
     if wg_heit > 5000 {
         return point;


### PR DESCRIPTION
Not sure if this crate is abandoned or not, but it was broken by a bugfix in rustc (see https://tools.taskcluster.net/task-inspector/#xojNw5StQjCKx3HB-lqyGg/0 and rust-lang/rust#34537 for more details).
Here's a fix - the trait `ToPoint` is made `pub`, but moved to a private inner module so it's still inaccessible. (I also fixed remaining warnings.)
