### PR TITLE
Make error module public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@
 extern crate postgres;
 extern crate byteorder;
 
-mod error;
+pub mod error;
 mod types;
 pub use types::{Point, LineString, Polygon, MultiPoint, MultiLineString, MultiPolygon};
 pub mod ewkb;


### PR DESCRIPTION
Making the error module private prevents other people from creating wrapper types for `std::convert::From<postgis::error::Error>`. Please make the error module public.