### PR TITLE
Make error module public to allow other libraries to wrap this type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@
 extern crate postgres;
 extern crate byteorder;
 
-mod error;
+pub mod error;
 mod types;
 pub use types::{Point, LineString, Polygon, MultiPoint, MultiLineString, MultiPolygon};
 pub mod ewkb;


### PR DESCRIPTION
I need the error module to be public, otherwise there is no way I can store the error or wrap it using `error-chain`. I don't think making errors private is a good idea.