### PR TITLE
Be forward compatible with rust-lang/rust#59928

### DIFF
--- a/src/ewkb.rs
+++ b/src/ewkb.rs
@@ -863,13 +863,13 @@ where
         &'a self,
     ) -> postgis::GeometryType<
         'a,
-        Self::Point,
-        Self::LineString,
-        Self::Polygon,
-        Self::MultiPoint,
-        Self::MultiLineString,
-        Self::MultiPolygon,
-        Self::GeometryCollection,
+        P,
+        LineStringT<P>,
+        PolygonT<P>,
+        MultiPointT<P>,
+        MultiLineStringT<P>,
+        MultiPolygonT<P>,
+        GeometryCollectionT<P>,
     > {
         use ewkb::GeometryT as A;
         use types::GeometryType as B;


### PR DESCRIPTION
Hello! In https://github.com/rust-lang/rust/pull/59928 we are making https://github.com/rust-lang/rust/issues/57644 a deny-by-default lint. To be forward compatible with that, here's a simple fix. Thank you for you understanding!