### PR TITLE
Dependency Modernization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ addons:
   postgresql: 9.6
   apt:
     packages:
-    - postgresql-9.6-postgis-2.3
+    - postgresql-9.6-postgis-2.4
 env:
   DBCONN=postgresql://postgres@127.0.0.1/testdb
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,10 +9,12 @@ readme = "README.md"
 documentation = "https://docs.rs/postgis/"
 keywords = ["PostgreSQL", "PostGIS", "GIS", "GEO"]
 license = "MIT"
+edition = "2018"
 
 [lib]
 doctest = false
 
 [dependencies]
-postgres = "^0.15"
+postgres = "^0.17"
 byteorder = "^0.5"
+bytes = "0.5"

--- a/src/ewkb.rs
+++ b/src/ewkb.rs
@@ -5,15 +5,14 @@
 //!
 //! Support for SRID information according to [PostGIS EWKB extensions](https://svn.osgeo.org/postgis/trunk/doc/ZMSgeoms.txt)
 
-use types as postgis;
-use std;
-use std::io::prelude::*;
-use std::mem;
-use std::fmt;
-use std::slice::Iter;
-use std::iter::FromIterator;
+use crate::{error::Error, types as postgis};
 use byteorder::{BigEndian, LittleEndian, ReadBytesExt, WriteBytesExt};
-use error::Error;
+use std;
+use std::fmt;
+use std::io::prelude::*;
+use std::iter::FromIterator;
+use std::mem;
+use std::slice::Iter;
 
 // --- Structs for reading PostGIS geometries into
 
@@ -115,7 +114,8 @@ pub trait EwkbWrite: fmt::Debug + Sized {
     fn to_hex_ewkb(&self) -> String {
         let mut buf: Vec<u8> = Vec::new();
         let _ = self.write_ewkb(&mut buf).unwrap();
-        let hex: String = buf.iter()
+        let hex: String = buf
+            .iter()
             .fold(String::new(), |s, &b| s + &format!("{:02X}", b));
         hex
     }
@@ -130,27 +130,27 @@ impl From<std::io::Error> for Error {
 }
 
 fn read_u32<R: Read>(raw: &mut R, is_be: bool) -> Result<u32, Error> {
-    Ok(try!(if is_be {
-        raw.read_u32::<BigEndian>()
+    Ok(if is_be {
+        raw.read_u32::<BigEndian>()?
     } else {
-        raw.read_u32::<LittleEndian>()
-    }))
+        raw.read_u32::<LittleEndian>()?
+    })
 }
 
 fn read_i32<R: Read>(raw: &mut R, is_be: bool) -> Result<i32, Error> {
-    Ok(try!(if is_be {
-        raw.read_i32::<BigEndian>()
+    Ok(if is_be {
+        raw.read_i32::<BigEndian>()?
     } else {
-        raw.read_i32::<LittleEndian>()
-    }))
+        raw.read_i32::<LittleEndian>()?
+    })
 }
 
 fn read_f64<R: Read>(raw: &mut R, is_be: bool) -> Result<f64, Error> {
-    Ok(try!(if is_be {
-        raw.read_f64::<BigEndian>()
+    Ok(if is_be {
+        raw.read_f64::<BigEndian>()?
     } else {
-        raw.read_f64::<LittleEndian>()
-    }))
+        raw.read_f64::<LittleEndian>()?
+    })
 }
 
 // --- Point
@@ -308,12 +308,16 @@ impl postgis::Point for PointZM {
 }
 
 macro_rules! impl_point_read_traits {
-    ($ptype:ident) => (
+    ($ptype:ident) => {
         impl EwkbRead for $ptype {
             fn point_type() -> PointType {
                 PointType::$ptype
             }
-            fn read_ewkb_body<R: Read>(raw: &mut R, is_be: bool, srid: Option<i32>) -> Result<Self, Error> {
+            fn read_ewkb_body<R: Read>(
+                raw: &mut R,
+                is_be: bool,
+                srid: Option<i32>,
+            ) -> Result<Self, Error> {
                 let x = read_f64(raw, is_be)?;
                 let y = read_f64(raw, is_be)?;
                 let z = if Self::has_z() {
@@ -332,10 +336,14 @@ macro_rules! impl_point_read_traits {
 
         impl<'a> AsEwkbPoint<'a> for $ptype {
             fn as_ewkb(&'a self) -> EwkbPoint<'a> {
-                EwkbPoint { geom: self, srid: self.srid, point_type: PointType::$ptype }
+                EwkbPoint {
+                    geom: self,
+                    srid: self.srid,
+                    point_type: PointType::$ptype,
+                }
             }
         }
-    )
+    };
 }
 
 impl_point_read_traits!(Point);
@@ -344,7 +352,7 @@ impl_point_read_traits!(PointM);
 impl_point_read_traits!(PointZM);
 
 pub struct EwkbPoint<'a> {
-    pub geom: &'a postgis::Point,
+    pub geom: &'a dyn postgis::Point,
     pub srid: Option<i32>,
     pub point_type: PointType,
 }
@@ -378,8 +386,7 @@ impl<'a> EwkbWrite for EwkbPoint<'a> {
 
 macro_rules! point_container_type {
     // geometries containing points
-    ($geotypetrait:ident for $geotype:ident) => (
-
+    ($geotypetrait:ident for $geotype:ident) => {
         #[derive(PartialEq, Clone, Debug)]
         pub struct $geotype<P: postgis::Point + EwkbRead> {
             pub points: Vec<P>,
@@ -388,15 +395,19 @@ macro_rules! point_container_type {
 
         impl<P: postgis::Point + EwkbRead> $geotype<P> {
             pub fn new() -> $geotype<P> {
-                $geotype { points: Vec::new(), srid: None }
+                $geotype {
+                    points: Vec::new(),
+                    srid: None,
+                }
             }
         }
 
         impl<P> FromIterator<P> for $geotype<P>
-            where P: postgis::Point + EwkbRead
+        where
+            P: postgis::Point + EwkbRead,
         {
             #[inline]
-            fn from_iter<I: IntoIterator<Item=P>>(iterable: I) -> $geotype<P> {
+            fn from_iter<I: IntoIterator<Item = P>>(iterable: I) -> $geotype<P> {
                 let iterator = iterable.into_iter();
                 let (lower, _) = iterator.size_hint();
                 let mut ret = $geotype::new();
@@ -409,7 +420,8 @@ macro_rules! point_container_type {
         }
 
         impl<'a, P> postgis::$geotypetrait<'a> for $geotype<P>
-            where P: 'a + postgis::Point + EwkbRead
+        where
+            P: 'a + postgis::Point + EwkbRead,
         {
             type ItemType = P;
             type Iter = Iter<'a, Self::ItemType>;
@@ -417,12 +429,12 @@ macro_rules! point_container_type {
                 self.points.iter()
             }
         }
-    )
+    };
 }
 
 macro_rules! geometry_container_type {
     // geometries containing lines and polygons
-    ($geotypetrait:ident for $geotype:ident contains $itemtype:ident named $itemname:ident) => (
+    ($geotypetrait:ident for $geotype:ident contains $itemtype:ident named $itemname:ident) => {
         #[derive(PartialEq, Clone, Debug)]
         pub struct $geotype<P: postgis::Point + EwkbRead> {
             pub $itemname: Vec<$itemtype<P>>,
@@ -430,18 +442,23 @@ macro_rules! geometry_container_type {
         }
 
         impl<P> $geotype<P>
-            where P: postgis::Point + EwkbRead
+        where
+            P: postgis::Point + EwkbRead,
         {
             pub fn new() -> $geotype<P> {
-                $geotype { $itemname: Vec::new(), srid: None }
+                $geotype {
+                    $itemname: Vec::new(),
+                    srid: None,
+                }
             }
         }
 
         impl<P> FromIterator<$itemtype<P>> for $geotype<P>
-            where P: postgis::Point + EwkbRead
+        where
+            P: postgis::Point + EwkbRead,
         {
             #[inline]
-            fn from_iter<I: IntoIterator<Item=$itemtype<P>>>(iterable: I) -> $geotype<P> {
+            fn from_iter<I: IntoIterator<Item = $itemtype<P>>>(iterable: I) -> $geotype<P> {
                 let iterator = iterable.into_iter();
                 let (lower, _) = iterator.size_hint();
                 let mut ret = $geotype::new();
@@ -454,7 +471,8 @@ macro_rules! geometry_container_type {
         }
 
         impl<'a, P> postgis::$geotypetrait<'a> for $geotype<P>
-            where P: 'a + postgis::Point + EwkbRead
+        where
+            P: 'a + postgis::Point + EwkbRead,
         {
             type ItemType = $itemtype<P>;
             type Iter = Iter<'a, Self::ItemType>;
@@ -462,106 +480,138 @@ macro_rules! geometry_container_type {
                 self.$itemname.iter()
             }
         }
-    )
+    };
 }
 
 macro_rules! impl_read_for_point_container_type {
-    (singletype $geotype:ident) => (
-
+    (singletype $geotype:ident) => {
         impl<P> EwkbRead for $geotype<P>
-            where P: postgis::Point + EwkbRead
+        where
+            P: postgis::Point + EwkbRead,
         {
             fn point_type() -> PointType {
                 P::point_type()
             }
-            fn read_ewkb_body<R: Read>(raw: &mut R, is_be: bool, srid: Option<i32>) -> Result<Self, Error> {
+            fn read_ewkb_body<R: Read>(
+                raw: &mut R,
+                is_be: bool,
+                srid: Option<i32>,
+            ) -> Result<Self, Error> {
                 let mut points: Vec<P> = vec![];
                 let size = read_u32(raw, is_be)? as usize;
                 for _ in 0..size {
                     points.push(P::read_ewkb_body(raw, is_be, srid)?);
                 }
-                Ok($geotype::<P> {points: points, srid: srid})
+                Ok($geotype::<P> {
+                    points: points,
+                    srid: srid,
+                })
             }
         }
-    );
-    (multitype $geotype:ident) => (
-
+    };
+    (multitype $geotype:ident) => {
         impl<P> EwkbRead for $geotype<P>
-            where P: postgis::Point + EwkbRead
+        where
+            P: postgis::Point + EwkbRead,
         {
             fn point_type() -> PointType {
                 P::point_type()
             }
-            fn read_ewkb_body<R: Read>(raw: &mut R, is_be: bool, srid: Option<i32>) -> Result<Self, Error> {
+            fn read_ewkb_body<R: Read>(
+                raw: &mut R,
+                is_be: bool,
+                srid: Option<i32>,
+            ) -> Result<Self, Error> {
                 let mut points: Vec<P> = vec![];
                 let size = read_u32(raw, is_be)? as usize;
                 for _ in 0..size {
                     points.push(P::read_ewkb(raw)?);
                 }
-                Ok($geotype::<P> {points: points, srid: srid})
+                Ok($geotype::<P> {
+                    points: points,
+                    srid: srid,
+                })
             }
         }
-    )
+    };
 }
 
 macro_rules! impl_read_for_geometry_container_type {
-    (singletype $geotype:ident contains $itemtype:ident named $itemname:ident) => (
+    (singletype $geotype:ident contains $itemtype:ident named $itemname:ident) => {
         impl<P> EwkbRead for $geotype<P>
-            where P: postgis::Point + EwkbRead
+        where
+            P: postgis::Point + EwkbRead,
         {
             fn point_type() -> PointType {
                 P::point_type()
             }
-            fn read_ewkb_body<R: Read>(raw: &mut R, is_be: bool, srid: Option<i32>) -> Result<Self, Error> {
+            fn read_ewkb_body<R: Read>(
+                raw: &mut R,
+                is_be: bool,
+                srid: Option<i32>,
+            ) -> Result<Self, Error> {
                 let mut $itemname: Vec<$itemtype<P>> = vec![];
                 let size = read_u32(raw, is_be)? as usize;
                 for _ in 0..size {
                     $itemname.push($itemtype::read_ewkb_body(raw, is_be, srid)?);
-                 }
-                Ok($geotype::<P> {$itemname: $itemname, srid: srid})
+                }
+                Ok($geotype::<P> {
+                    $itemname: $itemname,
+                    srid: srid,
+                })
             }
         }
-    );
-    (multitype $geotype:ident contains $itemtype:ident named $itemname:ident) => (
+    };
+    (multitype $geotype:ident contains $itemtype:ident named $itemname:ident) => {
         impl<P> EwkbRead for $geotype<P>
-            where P: postgis::Point + EwkbRead
+        where
+            P: postgis::Point + EwkbRead,
         {
             fn point_type() -> PointType {
                 P::point_type()
             }
-            fn read_ewkb_body<R: Read>(raw: &mut R, is_be: bool, srid: Option<i32>) -> Result<Self, Error> {
+            fn read_ewkb_body<R: Read>(
+                raw: &mut R,
+                is_be: bool,
+                srid: Option<i32>,
+            ) -> Result<Self, Error> {
                 let mut $itemname: Vec<$itemtype<P>> = vec![];
                 let size = read_u32(raw, is_be)? as usize;
                 for _ in 0..size {
                     $itemname.push($itemtype::read_ewkb(raw)?);
-                 }
-                Ok($geotype::<P> {$itemname: $itemname, srid: srid})
+                }
+                Ok($geotype::<P> {
+                    $itemname: $itemname,
+                    srid: srid,
+                })
             }
         }
-    )
+    };
 }
 
 macro_rules! point_container_write {
-    ($geotypetrait:ident and $asewkbtype:ident for $geotype:ident to $ewkbtype:ident with type code $typecode:expr, command $writecmd:ident) => (
-
+    ($geotypetrait:ident and $asewkbtype:ident for $geotype:ident to $ewkbtype:ident with type code $typecode:expr, command $writecmd:ident) => {
         pub struct $ewkbtype<'a, P, I>
-            where P: 'a + postgis::Point,
-                  I: 'a + Iterator<Item=&'a P> + ExactSizeIterator<Item=&'a P>
+        where
+            P: 'a + postgis::Point,
+            I: 'a + Iterator<Item = &'a P> + ExactSizeIterator<Item = &'a P>,
         {
-            pub geom: &'a postgis::$geotypetrait<'a, ItemType=P, Iter=I>,
+            pub geom: &'a postgis::$geotypetrait<'a, ItemType = P, Iter = I>,
             pub srid: Option<i32>,
             pub point_type: PointType,
         }
 
         pub trait $asewkbtype<'a> {
             type PointType: 'a + postgis::Point;
-            type Iter: Iterator<Item=&'a Self::PointType>+ExactSizeIterator<Item=&'a Self::PointType>;
+            type Iter: Iterator<Item = &'a Self::PointType>
+                + ExactSizeIterator<Item = &'a Self::PointType>;
             fn as_ewkb(&'a self) -> $ewkbtype<'a, Self::PointType, Self::Iter>;
         }
 
         impl<'a, T, I> fmt::Debug for $ewkbtype<'a, T, I>
-            where T: 'a + postgis::Point,
-                  I: 'a + Iterator<Item=&'a T> + ExactSizeIterator<Item=&'a T>
+        where
+            T: 'a + postgis::Point,
+            I: 'a + Iterator<Item = &'a T> + ExactSizeIterator<Item = &'a T>,
         {
             fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 write!(f, stringify!($ewkbtype))?; //TODO
@@ -570,8 +620,9 @@ macro_rules! point_container_write {
         }
 
         impl<'a, T, I> EwkbWrite for $ewkbtype<'a, T, I>
-            where T: 'a + postgis::Point,
-                  I: 'a + Iterator<Item=&'a T> + ExactSizeIterator<Item=&'a T>
+        where
+            T: 'a + postgis::Point,
+            I: 'a + Iterator<Item = &'a T> + ExactSizeIterator<Item = &'a T>,
         {
             fn opt_srid(&self) -> Option<i32> {
                 self.srid
@@ -581,10 +632,14 @@ macro_rules! point_container_write {
                 $typecode | Self::wkb_type_id(&self.point_type, self.srid)
             }
 
-            fn write_ewkb_body<W: Write+?Sized>(&self, w: &mut W) -> Result<(), Error> {
+            fn write_ewkb_body<W: Write + ?Sized>(&self, w: &mut W) -> Result<(), Error> {
                 w.write_u32::<LittleEndian>(self.geom.points().len() as u32)?;
                 for geom in self.geom.points() {
-                    let wkb = EwkbPoint { geom: geom, srid: None, point_type: self.point_type.clone() };
+                    let wkb = EwkbPoint {
+                        geom: geom,
+                        srid: None,
+                        point_type: self.point_type.clone(),
+                    };
                     wkb.$writecmd(w)?;
                 }
                 Ok(())
@@ -592,44 +647,55 @@ macro_rules! point_container_write {
         }
 
         impl<'a, P> $asewkbtype<'a> for $geotype<P>
-            where P: 'a + postgis::Point + EwkbRead
+        where
+            P: 'a + postgis::Point + EwkbRead,
         {
             type PointType = P;
             type Iter = Iter<'a, P>;
             fn as_ewkb(&'a self) -> $ewkbtype<'a, Self::PointType, Self::Iter> {
-                $ewkbtype { geom: self, srid: self.srid, point_type: Self::PointType::point_type() }
+                $ewkbtype {
+                    geom: self,
+                    srid: self.srid,
+                    point_type: Self::PointType::point_type(),
+                }
             }
         }
-    )
+    };
 }
 
 macro_rules! geometry_container_write {
-    ($geotypetrait:ident and $asewkbtype:ident for $geotype:ident to $ewkbtype:ident with type code $typecode:expr, contains $ewkbitemtype:ident, $itemtype:ident as $itemtypetrait:ident named $itemname:ident, command $writecmd:ident) => (
-
+    ($geotypetrait:ident and $asewkbtype:ident for $geotype:ident to $ewkbtype:ident with type code $typecode:expr, contains $ewkbitemtype:ident, $itemtype:ident as $itemtypetrait:ident named $itemname:ident, command $writecmd:ident) => {
         pub struct $ewkbtype<'a, P, I, T, J>
-            where P: 'a + postgis::Point,
-                  I: 'a + Iterator<Item=&'a P> + ExactSizeIterator<Item=&'a P>,
-                  T: 'a + postgis::$itemtypetrait<'a, ItemType=P, Iter=I>,
-                  J: 'a + Iterator<Item=&'a T> + ExactSizeIterator<Item=&'a T>
+        where
+            P: 'a + postgis::Point,
+            I: 'a + Iterator<Item = &'a P> + ExactSizeIterator<Item = &'a P>,
+            T: 'a + postgis::$itemtypetrait<'a, ItemType = P, Iter = I>,
+            J: 'a + Iterator<Item = &'a T> + ExactSizeIterator<Item = &'a T>,
         {
-            pub geom: &'a postgis::$geotypetrait<'a, ItemType=T, Iter=J>,
+            pub geom: &'a postgis::$geotypetrait<'a, ItemType = T, Iter = J>,
             pub srid: Option<i32>,
             pub point_type: PointType,
         }
 
         pub trait $asewkbtype<'a> {
             type PointType: 'a + postgis::Point;
-            type PointIter: Iterator<Item=&'a Self::PointType>+ExactSizeIterator<Item=&'a Self::PointType>;
-            type ItemType: 'a + postgis::$itemtypetrait<'a, ItemType=Self::PointType, Iter=Self::PointIter>;
-            type Iter: Iterator<Item=&'a Self::ItemType>+ExactSizeIterator<Item=&'a Self::ItemType>;
-            fn as_ewkb(&'a self) -> $ewkbtype<'a, Self::PointType, Self::PointIter, Self::ItemType, Self::Iter>;
+            type PointIter: Iterator<Item = &'a Self::PointType>
+                + ExactSizeIterator<Item = &'a Self::PointType>;
+            type ItemType: 'a
+                + postgis::$itemtypetrait<'a, ItemType = Self::PointType, Iter = Self::PointIter>;
+            type Iter: Iterator<Item = &'a Self::ItemType>
+                + ExactSizeIterator<Item = &'a Self::ItemType>;
+            fn as_ewkb(
+                &'a self,
+            ) -> $ewkbtype<'a, Self::PointType, Self::PointIter, Self::ItemType, Self::Iter>;
         }
 
         impl<'a, P, I, T, J> fmt::Debug for $ewkbtype<'a, P, I, T, J>
-            where P: 'a + postgis::Point,
-                  I: 'a + Iterator<Item=&'a P> + ExactSizeIterator<Item=&'a P>,
-                  T: 'a + postgis::$itemtypetrait<'a, ItemType=P, Iter=I>,
-                  J: 'a + Iterator<Item=&'a T> + ExactSizeIterator<Item=&'a T>
+        where
+            P: 'a + postgis::Point,
+            I: 'a + Iterator<Item = &'a P> + ExactSizeIterator<Item = &'a P>,
+            T: 'a + postgis::$itemtypetrait<'a, ItemType = P, Iter = I>,
+            J: 'a + Iterator<Item = &'a T> + ExactSizeIterator<Item = &'a T>,
         {
             fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 write!(f, stringify!($ewkbtype))?; //TODO
@@ -638,10 +704,11 @@ macro_rules! geometry_container_write {
         }
 
         impl<'a, P, I, T, J> EwkbWrite for $ewkbtype<'a, P, I, T, J>
-            where P: 'a + postgis::Point,
-                  I: 'a + Iterator<Item=&'a P> + ExactSizeIterator<Item=&'a P>,
-                  T: 'a + postgis::$itemtypetrait<'a, ItemType=P, Iter=I>,
-                  J: 'a + Iterator<Item=&'a T> + ExactSizeIterator<Item=&'a T>
+        where
+            P: 'a + postgis::Point,
+            I: 'a + Iterator<Item = &'a P> + ExactSizeIterator<Item = &'a P>,
+            T: 'a + postgis::$itemtypetrait<'a, ItemType = P, Iter = I>,
+            J: 'a + Iterator<Item = &'a T> + ExactSizeIterator<Item = &'a T>,
         {
             fn opt_srid(&self) -> Option<i32> {
                 self.srid
@@ -651,10 +718,14 @@ macro_rules! geometry_container_write {
                 $typecode | Self::wkb_type_id(&self.point_type, self.srid)
             }
 
-            fn write_ewkb_body<W: Write+?Sized>(&self, w: &mut W) -> Result<(), Error> {
+            fn write_ewkb_body<W: Write + ?Sized>(&self, w: &mut W) -> Result<(), Error> {
                 w.write_u32::<LittleEndian>(self.geom.$itemname().len() as u32)?;
                 for geom in self.geom.$itemname() {
-                    let wkb = $ewkbitemtype { geom: geom, srid: None, point_type: self.point_type.clone() };
+                    let wkb = $ewkbitemtype {
+                        geom: geom,
+                        srid: None,
+                        point_type: self.point_type.clone(),
+                    };
                     wkb.$writecmd(w)?;
                 }
                 Ok(())
@@ -662,48 +733,72 @@ macro_rules! geometry_container_write {
         }
 
         impl<'a, P> $asewkbtype<'a> for $geotype<P>
-            where P: 'a + postgis::Point + EwkbRead
+        where
+            P: 'a + postgis::Point + EwkbRead,
         {
             type PointType = P;
             type PointIter = Iter<'a, P>;
             type ItemType = $itemtype<P>;
             type Iter = Iter<'a, Self::ItemType>;
-            fn as_ewkb(&'a self) -> $ewkbtype<'a, Self::PointType, Self::PointIter, Self::ItemType, Self::Iter> {
-                $ewkbtype { geom: self, srid: self.srid, point_type: Self::PointType::point_type() }
+            fn as_ewkb(
+                &'a self,
+            ) -> $ewkbtype<'a, Self::PointType, Self::PointIter, Self::ItemType, Self::Iter> {
+                $ewkbtype {
+                    geom: self,
+                    srid: self.srid,
+                    point_type: Self::PointType::point_type(),
+                }
             }
         }
-    );
-    (multipoly $geotypetrait:ident and $asewkbtype:ident for $geotype:ident to $ewkbtype:ident with type code $typecode:expr, contains $ewkbitemtype:ident, $itemtype:ident as $itemtypetrait:ident named $itemname:ident, command $writecmd:ident) => (
+    };
+    (multipoly $geotypetrait:ident and $asewkbtype:ident for $geotype:ident to $ewkbtype:ident with type code $typecode:expr, contains $ewkbitemtype:ident, $itemtype:ident as $itemtypetrait:ident named $itemname:ident, command $writecmd:ident) => {
         pub struct $ewkbtype<'a, P, I, L, K, T, J>
-            where P: 'a + postgis::Point,
-                  I: 'a + Iterator<Item=&'a P> + ExactSizeIterator<Item=&'a P>,
-                  L: 'a + postgis::LineString<'a, ItemType=P, Iter=I>,
-                  K: 'a + Iterator<Item=&'a L> + ExactSizeIterator<Item=&'a L>,
-                  T: 'a + postgis::$itemtypetrait<'a, ItemType=L, Iter=K>,
-                  J: 'a + Iterator<Item=&'a T> + ExactSizeIterator<Item=&'a T>
+        where
+            P: 'a + postgis::Point,
+            I: 'a + Iterator<Item = &'a P> + ExactSizeIterator<Item = &'a P>,
+            L: 'a + postgis::LineString<'a, ItemType = P, Iter = I>,
+            K: 'a + Iterator<Item = &'a L> + ExactSizeIterator<Item = &'a L>,
+            T: 'a + postgis::$itemtypetrait<'a, ItemType = L, Iter = K>,
+            J: 'a + Iterator<Item = &'a T> + ExactSizeIterator<Item = &'a T>,
         {
-            pub geom: &'a postgis::$geotypetrait<'a, ItemType=T, Iter=J>,
+            pub geom: &'a postgis::$geotypetrait<'a, ItemType = T, Iter = J>,
             pub srid: Option<i32>,
             pub point_type: PointType,
         }
 
         pub trait $asewkbtype<'a> {
             type PointType: 'a + postgis::Point;
-            type PointIter: Iterator<Item=&'a Self::PointType>+ExactSizeIterator<Item=&'a Self::PointType>;
-            type LineType: 'a + postgis::LineString<'a, ItemType=Self::PointType, Iter=Self::PointIter>;
-            type LineIter: Iterator<Item=&'a Self::LineType>+ExactSizeIterator<Item=&'a Self::LineType>;
-            type ItemType: 'a + postgis::$itemtypetrait<'a, ItemType=Self::LineType, Iter=Self::LineIter>;
-            type Iter: Iterator<Item=&'a Self::ItemType>+ExactSizeIterator<Item=&'a Self::ItemType>;
-            fn as_ewkb(&'a self) -> $ewkbtype<'a, Self::PointType, Self::PointIter, Self::LineType, Self::LineIter, Self::ItemType, Self::Iter>;
+            type PointIter: Iterator<Item = &'a Self::PointType>
+                + ExactSizeIterator<Item = &'a Self::PointType>;
+            type LineType: 'a
+                + postgis::LineString<'a, ItemType = Self::PointType, Iter = Self::PointIter>;
+            type LineIter: Iterator<Item = &'a Self::LineType>
+                + ExactSizeIterator<Item = &'a Self::LineType>;
+            type ItemType: 'a
+                + postgis::$itemtypetrait<'a, ItemType = Self::LineType, Iter = Self::LineIter>;
+            type Iter: Iterator<Item = &'a Self::ItemType>
+                + ExactSizeIterator<Item = &'a Self::ItemType>;
+            fn as_ewkb(
+                &'a self,
+            ) -> $ewkbtype<
+                'a,
+                Self::PointType,
+                Self::PointIter,
+                Self::LineType,
+                Self::LineIter,
+                Self::ItemType,
+                Self::Iter,
+            >;
         }
 
         impl<'a, P, I, L, K, T, J> fmt::Debug for $ewkbtype<'a, P, I, L, K, T, J>
-            where P: 'a + postgis::Point,
-                  I: 'a + Iterator<Item=&'a P> + ExactSizeIterator<Item=&'a P>,
-                  L: 'a + postgis::LineString<'a, ItemType=P, Iter=I>,
-                  K: 'a + Iterator<Item=&'a L> + ExactSizeIterator<Item=&'a L>,
-                  T: 'a + postgis::$itemtypetrait<'a, ItemType=L, Iter=K>,
-                  J: 'a + Iterator<Item=&'a T> + ExactSizeIterator<Item=&'a T>
+        where
+            P: 'a + postgis::Point,
+            I: 'a + Iterator<Item = &'a P> + ExactSizeIterator<Item = &'a P>,
+            L: 'a + postgis::LineString<'a, ItemType = P, Iter = I>,
+            K: 'a + Iterator<Item = &'a L> + ExactSizeIterator<Item = &'a L>,
+            T: 'a + postgis::$itemtypetrait<'a, ItemType = L, Iter = K>,
+            J: 'a + Iterator<Item = &'a T> + ExactSizeIterator<Item = &'a T>,
         {
             fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 write!(f, stringify!($ewkbtype))?; //TODO
@@ -712,12 +807,13 @@ macro_rules! geometry_container_write {
         }
 
         impl<'a, P, I, L, K, T, J> EwkbWrite for $ewkbtype<'a, P, I, L, K, T, J>
-            where P: 'a + postgis::Point,
-                  I: 'a + Iterator<Item=&'a P> + ExactSizeIterator<Item=&'a P>,
-                  L: 'a + postgis::LineString<'a, ItemType=P, Iter=I>,
-                  K: 'a + Iterator<Item=&'a L> + ExactSizeIterator<Item=&'a L>,
-                  T: 'a + postgis::$itemtypetrait<'a, ItemType=L, Iter=K>,
-                  J: 'a + Iterator<Item=&'a T> + ExactSizeIterator<Item=&'a T>
+        where
+            P: 'a + postgis::Point,
+            I: 'a + Iterator<Item = &'a P> + ExactSizeIterator<Item = &'a P>,
+            L: 'a + postgis::LineString<'a, ItemType = P, Iter = I>,
+            K: 'a + Iterator<Item = &'a L> + ExactSizeIterator<Item = &'a L>,
+            T: 'a + postgis::$itemtypetrait<'a, ItemType = L, Iter = K>,
+            J: 'a + Iterator<Item = &'a T> + ExactSizeIterator<Item = &'a T>,
         {
             fn opt_srid(&self) -> Option<i32> {
                 self.srid
@@ -727,10 +823,14 @@ macro_rules! geometry_container_write {
                 $typecode | Self::wkb_type_id(&self.point_type, self.srid)
             }
 
-            fn write_ewkb_body<W: Write+?Sized>(&self, w: &mut W) -> Result<(), Error> {
+            fn write_ewkb_body<W: Write + ?Sized>(&self, w: &mut W) -> Result<(), Error> {
                 w.write_u32::<LittleEndian>(self.geom.$itemname().len() as u32)?;
                 for geom in self.geom.$itemname() {
-                    let wkb = $ewkbitemtype { geom: geom, srid: None, point_type: self.point_type.clone() };
+                    let wkb = $ewkbitemtype {
+                        geom: geom,
+                        srid: None,
+                        point_type: self.point_type.clone(),
+                    };
                     wkb.$writecmd(w)?;
                 }
                 Ok(())
@@ -738,7 +838,8 @@ macro_rules! geometry_container_write {
         }
 
         impl<'a, P> $asewkbtype<'a> for $geotype<P>
-            where P: 'a + postgis::Point + EwkbRead
+        where
+            P: 'a + postgis::Point + EwkbRead,
         {
             type PointType = P;
             type PointIter = Iter<'a, P>;
@@ -746,11 +847,25 @@ macro_rules! geometry_container_write {
             type LineIter = Iter<'a, Self::LineType>;
             type ItemType = $itemtype<P>;
             type Iter = Iter<'a, Self::ItemType>;
-            fn as_ewkb(&'a self) -> $ewkbtype<'a, Self::PointType, Self::PointIter, Self::LineType, Self::LineIter, Self::ItemType, Self::Iter> {
-                $ewkbtype { geom: self, srid: self.srid, point_type: Self::PointType::point_type() }
+            fn as_ewkb(
+                &'a self,
+            ) -> $ewkbtype<
+                'a,
+                Self::PointType,
+                Self::PointIter,
+                Self::LineType,
+                Self::LineIter,
+                Self::ItemType,
+                Self::Iter,
+            > {
+                $ewkbtype {
+                    geom: self,
+                    srid: self.srid,
+                    point_type: Self::PointType::point_type(),
+                }
             }
         }
-    );
+    };
 }
 
 /// LineString
@@ -871,8 +986,8 @@ where
         MultiPolygonT<P>,
         GeometryCollectionT<P>,
     > {
-        use ewkb::GeometryT as A;
-        use types::GeometryType as B;
+        use crate::ewkb::GeometryT as A;
+        use crate::types::GeometryType as B;
         match *self {
             A::Point(ref geom) => B::Point(geom),
             A::LineString(ref geom) => B::LineString(geom),
@@ -910,9 +1025,7 @@ where
             0x05 => GeometryT::MultiLineString(MultiLineStringT::read_ewkb_body(raw, is_be, srid)?),
             0x06 => GeometryT::MultiPolygon(MultiPolygonT::read_ewkb_body(raw, is_be, srid)?),
             0x07 => GeometryT::GeometryCollection(GeometryCollectionT::read_ewkb_body(
-                raw,
-                is_be,
-                srid,
+                raw, is_be, srid,
             )?),
             _ => {
                 return Err(Error::Read(format!(
@@ -945,15 +1058,15 @@ where
     MY: 'a + postgis::MultiPolygon<'a, ItemType = Y, Iter = YI>,
     G: 'a
         + postgis::Geometry<
-        'a,
-        Point = P,
-        LineString = L,
-        Polygon = Y,
-        MultiPoint = MP,
-        MultiLineString = ML,
-        MultiPolygon = MY,
-        GeometryCollection = GC,
-    >,
+            'a,
+            Point = P,
+            LineString = L,
+            Polygon = Y,
+            MultiPoint = MP,
+            MultiLineString = ML,
+            MultiPolygon = MY,
+            GeometryCollection = GC,
+        >,
     GI: 'a + Iterator<Item = &'a G> + ExactSizeIterator<Item = &'a G>,
     GC: 'a + postgis::GeometryCollection<'a, ItemType = G, Iter = GI>,
 {
@@ -976,11 +1089,7 @@ pub trait AsEwkbGeometry<'a> {
     type LineIter: Iterator<Item = &'a Self::LineType>
         + ExactSizeIterator<Item = &'a Self::LineType>;
     type MultiLineType: 'a
-        + postgis::MultiLineString<
-        'a,
-        ItemType = Self::LineType,
-        Iter = Self::LineIter,
-    >;
+        + postgis::MultiLineString<'a, ItemType = Self::LineType, Iter = Self::LineIter>;
     type PolyType: 'a + postgis::Polygon<'a, ItemType = Self::LineType, Iter = Self::LineIter>;
     type PolyIter: Iterator<Item = &'a Self::PolyType>
         + ExactSizeIterator<Item = &'a Self::PolyType>;
@@ -988,23 +1097,19 @@ pub trait AsEwkbGeometry<'a> {
         + postgis::MultiPolygon<'a, ItemType = Self::PolyType, Iter = Self::PolyIter>;
     type GeomType: 'a
         + postgis::Geometry<
-        'a,
-        Point = Self::PointType,
-        LineString = Self::LineType,
-        Polygon = Self::PolyType,
-        MultiPoint = Self::MultiPointType,
-        MultiLineString = Self::MultiLineType,
-        MultiPolygon = Self::MultiPolyType,
-        GeometryCollection = Self::GeomCollection,
-    >;
+            'a,
+            Point = Self::PointType,
+            LineString = Self::LineType,
+            Polygon = Self::PolyType,
+            MultiPoint = Self::MultiPointType,
+            MultiLineString = Self::MultiLineType,
+            MultiPolygon = Self::MultiPolyType,
+            GeometryCollection = Self::GeomCollection,
+        >;
     type GeomIter: Iterator<Item = &'a Self::GeomType>
         + ExactSizeIterator<Item = &'a Self::GeomType>;
     type GeomCollection: 'a
-        + postgis::GeometryCollection<
-        'a,
-        ItemType = Self::GeomType,
-        Iter = Self::GeomIter,
-    >;
+        + postgis::GeometryCollection<'a, ItemType = Self::GeomType, Iter = Self::GeomIter>;
     fn as_ewkb(
         &'a self,
     ) -> EwkbGeometry<
@@ -1038,15 +1143,15 @@ where
     MY: 'a + postgis::MultiPolygon<'a, ItemType = Y, Iter = YI>,
     G: 'a
         + postgis::Geometry<
-        'a,
-        Point = P,
-        LineString = L,
-        Polygon = Y,
-        MultiPoint = MP,
-        MultiLineString = ML,
-        MultiPolygon = MY,
-        GeometryCollection = GC,
-    >,
+            'a,
+            Point = P,
+            LineString = L,
+            Polygon = Y,
+            MultiPoint = MP,
+            MultiLineString = ML,
+            MultiPolygon = MY,
+            GeometryCollection = GC,
+        >,
     GI: 'a + Iterator<Item = &'a G> + ExactSizeIterator<Item = &'a G>,
     GC: 'a + postgis::GeometryCollection<'a, ItemType = G, Iter = GI>,
 {
@@ -1070,15 +1175,15 @@ where
     MY: 'a + postgis::MultiPolygon<'a, ItemType = Y, Iter = YI>,
     G: 'a
         + postgis::Geometry<
-        'a,
-        Point = P,
-        LineString = L,
-        Polygon = Y,
-        MultiPoint = MP,
-        MultiLineString = ML,
-        MultiPolygon = MY,
-        GeometryCollection = GC,
-    >,
+            'a,
+            Point = P,
+            LineString = L,
+            Polygon = Y,
+            MultiPoint = MP,
+            MultiLineString = ML,
+            MultiPolygon = MY,
+            GeometryCollection = GC,
+        >,
     GI: 'a + Iterator<Item = &'a G> + ExactSizeIterator<Item = &'a G>,
     GC: 'a + postgis::GeometryCollection<'a, ItemType = G, Iter = GI>,
 {
@@ -1237,9 +1342,7 @@ where
                 }
                 0x06 => GeometryT::MultiPolygon(MultiPolygonT::read_ewkb_body(raw, is_be, srid)?),
                 0x07 => GeometryT::GeometryCollection(GeometryCollectionT::read_ewkb_body(
-                    raw,
-                    is_be,
-                    srid,
+                    raw, is_be, srid,
                 )?),
                 _ => {
                     return Err(Error::Read(format!(
@@ -1267,15 +1370,15 @@ where
     MY: 'a + postgis::MultiPolygon<'a, ItemType = Y, Iter = YI>,
     G: 'a
         + postgis::Geometry<
-        'a,
-        Point = P,
-        LineString = L,
-        Polygon = Y,
-        MultiPoint = MP,
-        MultiLineString = ML,
-        MultiPolygon = MY,
-        GeometryCollection = GC,
-    >,
+            'a,
+            Point = P,
+            LineString = L,
+            Polygon = Y,
+            MultiPoint = MP,
+            MultiLineString = ML,
+            MultiPolygon = MY,
+            GeometryCollection = GC,
+        >,
     GI: 'a + Iterator<Item = &'a G> + ExactSizeIterator<Item = &'a G>,
     GC: 'a + postgis::GeometryCollection<'a, ItemType = G, Iter = GI>,
 {
@@ -1294,11 +1397,7 @@ pub trait AsEwkbGeometryCollection<'a> {
     type LineIter: Iterator<Item = &'a Self::LineType>
         + ExactSizeIterator<Item = &'a Self::LineType>;
     type MultiLineType: 'a
-        + postgis::MultiLineString<
-        'a,
-        ItemType = Self::LineType,
-        Iter = Self::LineIter,
-    >;
+        + postgis::MultiLineString<'a, ItemType = Self::LineType, Iter = Self::LineIter>;
     type PolyType: 'a + postgis::Polygon<'a, ItemType = Self::LineType, Iter = Self::LineIter>;
     type PolyIter: Iterator<Item = &'a Self::PolyType>
         + ExactSizeIterator<Item = &'a Self::PolyType>;
@@ -1306,23 +1405,19 @@ pub trait AsEwkbGeometryCollection<'a> {
         + postgis::MultiPolygon<'a, ItemType = Self::PolyType, Iter = Self::PolyIter>;
     type GeomType: 'a
         + postgis::Geometry<
-        'a,
-        Point = Self::PointType,
-        LineString = Self::LineType,
-        Polygon = Self::PolyType,
-        MultiPoint = Self::MultiPointType,
-        MultiLineString = Self::MultiLineType,
-        MultiPolygon = Self::MultiPolyType,
-        GeometryCollection = Self::GeomCollection,
-    >;
+            'a,
+            Point = Self::PointType,
+            LineString = Self::LineType,
+            Polygon = Self::PolyType,
+            MultiPoint = Self::MultiPointType,
+            MultiLineString = Self::MultiLineType,
+            MultiPolygon = Self::MultiPolyType,
+            GeometryCollection = Self::GeomCollection,
+        >;
     type GeomIter: Iterator<Item = &'a Self::GeomType>
         + ExactSizeIterator<Item = &'a Self::GeomType>;
     type GeomCollection: 'a
-        + postgis::GeometryCollection<
-        'a,
-        ItemType = Self::GeomType,
-        Iter = Self::GeomIter,
-    >;
+        + postgis::GeometryCollection<'a, ItemType = Self::GeomType, Iter = Self::GeomIter>;
     fn as_ewkb(
         &'a self,
     ) -> EwkbGeometryCollection<
@@ -1356,15 +1451,15 @@ where
     MY: 'a + postgis::MultiPolygon<'a, ItemType = Y, Iter = YI>,
     G: 'a
         + postgis::Geometry<
-        'a,
-        Point = P,
-        LineString = L,
-        Polygon = Y,
-        MultiPoint = MP,
-        MultiLineString = ML,
-        MultiPolygon = MY,
-        GeometryCollection = GC,
-    >,
+            'a,
+            Point = P,
+            LineString = L,
+            Polygon = Y,
+            MultiPoint = MP,
+            MultiLineString = ML,
+            MultiPolygon = MY,
+            GeometryCollection = GC,
+        >,
     GI: 'a + Iterator<Item = &'a G> + ExactSizeIterator<Item = &'a G>,
     GC: 'a + postgis::GeometryCollection<'a, ItemType = G, Iter = GI>,
 {
@@ -1388,15 +1483,15 @@ where
     MY: 'a + postgis::MultiPolygon<'a, ItemType = Y, Iter = YI>,
     G: 'a
         + postgis::Geometry<
-        'a,
-        Point = P,
-        LineString = L,
-        Polygon = Y,
-        MultiPoint = MP,
-        MultiLineString = ML,
-        MultiPolygon = MY,
-        GeometryCollection = GC,
-    >,
+            'a,
+            Point = P,
+            LineString = L,
+            Polygon = Y,
+            MultiPoint = MP,
+            MultiLineString = ML,
+            MultiPolygon = MY,
+            GeometryCollection = GC,
+        >,
     GI: 'a + Iterator<Item = &'a G> + ExactSizeIterator<Item = &'a G>,
     GC: 'a + postgis::GeometryCollection<'a, ItemType = G, Iter = GI>,
 {
@@ -1780,7 +1875,7 @@ fn test_read_error() {
 #[cfg_attr(rustfmt, rustfmt_skip)]
 fn test_iterators() {
     // Iterator traits:
-    use types::LineString;
+    use crate::types::LineString;
 
     let p = |x, y| Point { x: x, y: y, srid: None };
     let line = self::LineStringT::<Point> {srid: Some(4326), points: vec![p(10.0, -20.0), p(0., -0.5)]};

--- a/src/ewkb.rs
+++ b/src/ewkb.rs
@@ -596,7 +596,7 @@ macro_rules! point_container_write {
             P: 'a + postgis::Point,
             I: 'a + Iterator<Item = &'a P> + ExactSizeIterator<Item = &'a P>,
         {
-            pub geom: &'a postgis::$geotypetrait<'a, ItemType = P, Iter = I>,
+            pub geom: &'a dyn postgis::$geotypetrait<'a, ItemType = P, Iter = I>,
             pub srid: Option<i32>,
             pub point_type: PointType,
         }
@@ -672,7 +672,7 @@ macro_rules! geometry_container_write {
             T: 'a + postgis::$itemtypetrait<'a, ItemType = P, Iter = I>,
             J: 'a + Iterator<Item = &'a T> + ExactSizeIterator<Item = &'a T>,
         {
-            pub geom: &'a postgis::$geotypetrait<'a, ItemType = T, Iter = J>,
+            pub geom: &'a dyn postgis::$geotypetrait<'a, ItemType = T, Iter = J>,
             pub srid: Option<i32>,
             pub point_type: PointType,
         }
@@ -761,7 +761,7 @@ macro_rules! geometry_container_write {
             T: 'a + postgis::$itemtypetrait<'a, ItemType = L, Iter = K>,
             J: 'a + Iterator<Item = &'a T> + ExactSizeIterator<Item = &'a T>,
         {
-            pub geom: &'a postgis::$geotypetrait<'a, ItemType = T, Iter = J>,
+            pub geom: &'a dyn postgis::$geotypetrait<'a, ItemType = T, Iter = J>,
             pub srid: Option<i32>,
             pub point_type: PointType,
         }
@@ -868,6 +868,7 @@ macro_rules! geometry_container_write {
     };
 }
 
+#[allow(unused_doc_comments)]
 /// LineString
 point_container_type!(LineString for LineStringT);
 impl_read_for_point_container_type!(singletype LineStringT);
@@ -884,6 +885,7 @@ pub type LineStringM = LineStringT<PointM>;
 /// OGC LineStringZM type
 pub type LineStringZM = LineStringT<PointZM>;
 
+#[allow(unused_doc_comments)]
 /// Polygon
 geometry_container_type!(Polygon for PolygonT contains LineStringT named rings);
 impl_read_for_geometry_container_type!(singletype PolygonT contains LineStringT named rings);
@@ -901,6 +903,7 @@ pub type PolygonM = PolygonT<PointM>;
 /// OGC PolygonZM type
 pub type PolygonZM = PolygonT<PointZM>;
 
+#[allow(unused_doc_comments)]
 /// MultiPoint
 point_container_type!(MultiPoint for MultiPointT);
 impl_read_for_point_container_type!(multitype MultiPointT);
@@ -917,6 +920,7 @@ pub type MultiPointM = MultiPointT<PointM>;
 /// OGC MultiPointZM type
 pub type MultiPointZM = MultiPointT<PointZM>;
 
+#[allow(unused_doc_comments)]
 /// MultiLineString
 geometry_container_type!(MultiLineString for MultiLineStringT contains LineStringT named lines);
 impl_read_for_geometry_container_type!(multitype MultiLineStringT contains LineStringT named lines);
@@ -934,6 +938,7 @@ pub type MultiLineStringM = MultiLineStringT<PointM>;
 /// OGC MultiLineStringZM type
 pub type MultiLineStringZM = MultiLineStringT<PointZM>;
 
+#[allow(unused_doc_comments)]
 /// MultiPolygon
 geometry_container_type!(MultiPolygon for MultiPolygonT contains PolygonT named polygons);
 impl_read_for_geometry_container_type!(multitype MultiPolygonT contains PolygonT named polygons);
@@ -1382,7 +1387,7 @@ where
     GI: 'a + Iterator<Item = &'a G> + ExactSizeIterator<Item = &'a G>,
     GC: 'a + postgis::GeometryCollection<'a, ItemType = G, Iter = GI>,
 {
-    pub geom: &'a postgis::GeometryCollection<'a, ItemType = G, Iter = GI>,
+    pub geom: &'a dyn postgis::GeometryCollection<'a, ItemType = G, Iter = GI>,
     pub srid: Option<i32>,
     pub point_type: PointType,
 }

--- a/src/ewkb.rs
+++ b/src/ewkb.rs
@@ -387,6 +387,7 @@ impl<'a> EwkbWrite for EwkbPoint<'a> {
 macro_rules! point_container_type {
     // geometries containing points
     ($geotypetrait:ident for $geotype:ident) => {
+        /// $geotypetrait
         #[derive(PartialEq, Clone, Debug)]
         pub struct $geotype<P: postgis::Point + EwkbRead> {
             pub points: Vec<P>,
@@ -868,8 +869,6 @@ macro_rules! geometry_container_write {
     };
 }
 
-#[allow(unused_doc_comments)]
-/// LineString
 point_container_type!(LineString for LineStringT);
 impl_read_for_point_container_type!(singletype LineStringT);
 point_container_write!(LineString and AsEwkbLineString for LineStringT
@@ -885,8 +884,6 @@ pub type LineStringM = LineStringT<PointM>;
 /// OGC LineStringZM type
 pub type LineStringZM = LineStringT<PointZM>;
 
-#[allow(unused_doc_comments)]
-/// Polygon
 geometry_container_type!(Polygon for PolygonT contains LineStringT named rings);
 impl_read_for_geometry_container_type!(singletype PolygonT contains LineStringT named rings);
 geometry_container_write!(Polygon and AsEwkbPolygon for PolygonT
@@ -903,8 +900,6 @@ pub type PolygonM = PolygonT<PointM>;
 /// OGC PolygonZM type
 pub type PolygonZM = PolygonT<PointZM>;
 
-#[allow(unused_doc_comments)]
-/// MultiPoint
 point_container_type!(MultiPoint for MultiPointT);
 impl_read_for_point_container_type!(multitype MultiPointT);
 point_container_write!(MultiPoint and AsEwkbMultiPoint for MultiPointT
@@ -920,8 +915,6 @@ pub type MultiPointM = MultiPointT<PointM>;
 /// OGC MultiPointZM type
 pub type MultiPointZM = MultiPointT<PointZM>;
 
-#[allow(unused_doc_comments)]
-/// MultiLineString
 geometry_container_type!(MultiLineString for MultiLineStringT contains LineStringT named lines);
 impl_read_for_geometry_container_type!(multitype MultiLineStringT contains LineStringT named lines);
 geometry_container_write!(MultiLineString and AsEwkbMultiLineString for MultiLineStringT
@@ -938,8 +931,6 @@ pub type MultiLineStringM = MultiLineStringT<PointM>;
 /// OGC MultiLineStringZM type
 pub type MultiLineStringZM = MultiLineStringT<PointZM>;
 
-#[allow(unused_doc_comments)]
-/// MultiPolygon
 geometry_container_type!(MultiPolygon for MultiPolygonT contains PolygonT named polygons);
 impl_read_for_geometry_container_type!(multitype MultiPolygonT contains PolygonT named polygons);
 geometry_container_write!(multipoly MultiPolygon and AsEwkbMultiPolygon for MultiPolygonT

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,14 +35,10 @@
 //! }
 //! ```
 
-extern crate byteorder;
-#[macro_use(accepts, to_sql_checked)]
-extern crate postgres;
-
 pub mod error;
 mod types;
 pub use types::{LineString, MultiLineString, MultiPoint, MultiPolygon, Point, Polygon};
 pub mod ewkb;
-pub mod twkb;
-mod postgis;
 pub mod mars;
+mod postgis;
+pub mod twkb;

--- a/src/mars.rs
+++ b/src/mars.rs
@@ -7,7 +7,7 @@
 
 //! Conversion between GCJ-02 and WGS-84 coordinates.
 
-use ewkb;
+use crate::ewkb;
 
 // http://emq.googlecode.com/svn/emq/src/Algorithm/Coords/Converter.java
 struct Converter {

--- a/src/postgis.rs
+++ b/src/postgis.rs
@@ -365,7 +365,7 @@ mod tests {
         // Missing SRID
         let point = ewkb::Point { x: 10.0, y: -20.0, srid: None };
         let result = conn.execute("INSERT INTO geomtests (geom) VALUES ($1)", &[&point]);
-        assert_eq!(result.err().unwrap().description(), "database error");
+        assert!(format!("{}", result.err().unwrap()).starts_with("db error"));
     }
 
     #[test]
@@ -542,7 +542,7 @@ mod tests {
 
         let result = or_panic!(conn.query("SELECT NULL::geometry(Point)", &[]));
         let point = result.iter().map(|r| r.try_get::<_, ewkb::Point>(0)).last().unwrap();
-        assert_eq!(&format!("{:?}", point), "Some(Err(Error(Conversion(WasNull))))");
+        assert_eq!(&format!("{:?}", point), "Err(Error { kind: FromSql(0), cause: Some(WasNull) })");
     }
 
     #[test]
@@ -634,7 +634,7 @@ mod tests {
         let mut conn = connect();
         let result = or_panic!(conn.query("SELECT ('LINESTRING (10 -20, -0 -0.5)')::geometry", &[]));
         let poly = result.iter().map(|r| r.try_get::<_, ewkb::Polygon>(0)).last().unwrap();
-        assert_eq!(format!("{:?}", poly), "Some(Err(Error(Conversion(StringError(\"cannot convert geometry to PolygonT\")))))");
+        assert_eq!(format!("{:?}", poly), "Err(Error { kind: FromSql(0), cause: Some(\"cannot convert geometry to PolygonT\") })");
     }
 
     #[test]
@@ -658,7 +658,7 @@ mod tests {
 
         let result = or_panic!(conn.query("SELECT ST_AsTWKB(NULL::geometry(Point))", &[]));
         let point = result.iter().map(|r| r.try_get::<_, twkb::Point>(0)).last().unwrap();
-        assert_eq!(&format!("{:?}", point), "Some(Err(Error(Conversion(WasNull))))");
+        assert_eq!(&format!("{:?}", point), "Err(Error { kind: FromSql(0), cause: Some(WasNull) })");
 
         let result = or_panic!(conn.query("SELECT ST_AsTWKB('LINESTRING (10 -20, -0 -0.5)'::geometry, 1)", &[]));
         let line = result.iter().map(|r| r.get::<_, twkb::LineString>(0)).last().unwrap();

--- a/src/postgis.rs
+++ b/src/postgis.rs
@@ -27,7 +27,7 @@ macro_rules! accepts_geography {
 }
 
 impl<'a> ToSql for ewkb::EwkbPoint<'a> {
-    fn to_sql(&self, _: &Type, out: &mut BytesMut) -> Result<IsNull, Box<Error + Sync + Send>> {
+    fn to_sql(&self, _: &Type, out: &mut BytesMut) -> Result<IsNull, Box<dyn Error + Sync + Send>> {
         self.write_ewkb(&mut out.writer())?;
         Ok(IsNull::No)
     }
@@ -39,7 +39,7 @@ impl<'a> ToSql for ewkb::EwkbPoint<'a> {
 macro_rules! impl_sql_for_point_type {
     ($ptype:ident) => {
         impl<'a> FromSql<'a> for ewkb::$ptype {
-            fn from_sql(ty: &Type, raw: &[u8]) -> Result<Self, Box<Error + Sync + Send>> {
+            fn from_sql(ty: &Type, raw: &[u8]) -> Result<Self, Box<dyn Error + Sync + Send>> {
                 let mut rdr = Cursor::new(raw);
                 ewkb::$ptype::read_ewkb(&mut rdr)
                     .map_err(|_| format!("cannot convert {} to {}", ty, stringify!($ptype)).into())
@@ -53,7 +53,7 @@ macro_rules! impl_sql_for_point_type {
                 &self,
                 _: &Type,
                 out: &mut BytesMut,
-            ) -> Result<IsNull, Box<Error + Sync + Send>> {
+            ) -> Result<IsNull, Box<dyn Error + Sync + Send>> {
                 self.as_ewkb().write_ewkb(&mut out.writer())?;
                 Ok(IsNull::No)
             }
@@ -75,7 +75,7 @@ macro_rules! impl_sql_for_geom_type {
         where
             T: 'a + Point + EwkbRead,
         {
-            fn from_sql(ty: &Type, raw: &[u8]) -> Result<Self, Box<Error + Sync + Send>> {
+            fn from_sql(ty: &Type, raw: &[u8]) -> Result<Self, Box<dyn Error + Sync + Send>> {
                 let mut rdr = Cursor::new(raw);
                 ewkb::$geotype::<T>::read_ewkb(&mut rdr).map_err(|_| {
                     format!("cannot convert {} to {}", ty, stringify!($geotype)).into()
@@ -93,7 +93,7 @@ macro_rules! impl_sql_for_geom_type {
                 &self,
                 _: &Type,
                 out: &mut BytesMut,
-            ) -> Result<IsNull, Box<Error + Sync + Send>> {
+            ) -> Result<IsNull, Box<dyn Error + Sync + Send>> {
                 self.as_ewkb().write_ewkb(&mut out.writer())?;
                 Ok(IsNull::No)
             }
@@ -121,7 +121,7 @@ macro_rules! impl_sql_for_ewkb_type {
                 &self,
                 _: &Type,
                 out: &mut BytesMut,
-            ) -> Result<IsNull, Box<Error + Sync + Send>> {
+            ) -> Result<IsNull, Box<dyn Error + Sync + Send>> {
                 self.write_ewkb(&mut out.writer())?;
                 Ok(IsNull::No)
             }
@@ -142,7 +142,7 @@ macro_rules! impl_sql_for_ewkb_type {
                 &self,
                 _: &Type,
                 out: &mut BytesMut,
-            ) -> Result<IsNull, Box<Error + Sync + Send>> {
+            ) -> Result<IsNull, Box<dyn Error + Sync + Send>> {
                 self.write_ewkb(&mut out.writer())?;
                 Ok(IsNull::No)
             }
@@ -167,7 +167,7 @@ macro_rules! impl_sql_for_ewkb_type {
                 &self,
                 _: &Type,
                 out: &mut BytesMut,
-            ) -> Result<IsNull, Box<Error + Sync + Send>> {
+            ) -> Result<IsNull, Box<dyn Error + Sync + Send>> {
                 self.write_ewkb(&mut out.writer())?;
                 Ok(IsNull::No)
             }
@@ -185,7 +185,7 @@ impl<'a, P> FromSql<'a> for ewkb::GeometryT<P>
 where
     P: Point + EwkbRead,
 {
-    fn from_sql(ty: &Type, raw: &[u8]) -> Result<Self, Box<Error + Sync + Send>> {
+    fn from_sql(ty: &Type, raw: &[u8]) -> Result<Self, Box<dyn Error + Sync + Send>> {
         let mut rdr = Cursor::new(raw);
         ewkb::GeometryT::<P>::read_ewkb(&mut rdr)
             .map_err(|_| format!("cannot convert {} to {}", ty, stringify!(P)).into())
@@ -202,7 +202,7 @@ macro_rules! impl_geometry_to_sql {
                 &self,
                 _: &Type,
                 out: &mut BytesMut,
-            ) -> Result<IsNull, Box<Error + Sync + Send>> {
+            ) -> Result<IsNull, Box<dyn Error + Sync + Send>> {
                 self.as_ewkb().write_ewkb(&mut out.writer())?;
                 Ok(IsNull::No)
             }
@@ -222,7 +222,7 @@ impl<'a, P> FromSql<'a> for ewkb::GeometryCollectionT<P>
 where
     P: Point + EwkbRead,
 {
-    fn from_sql(ty: &Type, raw: &[u8]) -> Result<Self, Box<Error + Sync + Send>> {
+    fn from_sql(ty: &Type, raw: &[u8]) -> Result<Self, Box<dyn Error + Sync + Send>> {
         let mut rdr = Cursor::new(raw);
         ewkb::GeometryCollectionT::<P>::read_ewkb(&mut rdr)
             .map_err(|_| format!("cannot convert {} to {}", ty, stringify!(P)).into())
@@ -235,7 +235,7 @@ impl<'a, P> ToSql for ewkb::GeometryCollectionT<P>
 where
     P: Point + EwkbRead,
 {
-    fn to_sql(&self, _: &Type, out: &mut BytesMut) -> Result<IsNull, Box<Error + Sync + Send>> {
+    fn to_sql(&self, _: &Type, out: &mut BytesMut) -> Result<IsNull, Box<dyn Error + Sync + Send>> {
         self.as_ewkb().write_ewkb(&mut out.writer())?;
         Ok(IsNull::No)
     }
@@ -247,7 +247,7 @@ where
 // --- TWKB ---
 
 impl<'a> FromSql<'a> for twkb::Point {
-    fn from_sql(ty: &Type, raw: &[u8]) -> Result<Self, Box<Error + Sync + Send>> {
+    fn from_sql(ty: &Type, raw: &[u8]) -> Result<Self, Box<dyn Error + Sync + Send>> {
         let mut rdr = Cursor::new(raw);
         twkb::Point::read_twkb(&mut rdr)
             .map_err(|_| format!("cannot convert {} to Point", ty).into())
@@ -257,7 +257,7 @@ impl<'a> FromSql<'a> for twkb::Point {
 }
 
 impl<'a> FromSql<'a> for twkb::LineString {
-    fn from_sql(ty: &Type, raw: &[u8]) -> Result<Self, Box<Error + Sync + Send>> {
+    fn from_sql(ty: &Type, raw: &[u8]) -> Result<Self, Box<dyn Error + Sync + Send>> {
         let mut rdr = Cursor::new(raw);
         twkb::LineString::read_twkb(&mut rdr)
             .map_err(|_| format!("cannot convert {} to LineString", ty).into())
@@ -267,7 +267,7 @@ impl<'a> FromSql<'a> for twkb::LineString {
 }
 
 impl<'a> FromSql<'a> for twkb::Polygon {
-    fn from_sql(ty: &Type, raw: &[u8]) -> Result<Self, Box<Error + Sync + Send>> {
+    fn from_sql(ty: &Type, raw: &[u8]) -> Result<Self, Box<dyn Error + Sync + Send>> {
         let mut rdr = Cursor::new(raw);
         twkb::Polygon::read_twkb(&mut rdr)
             .map_err(|_| format!("cannot convert {} to Polygon", ty).into())
@@ -278,7 +278,7 @@ impl<'a> FromSql<'a> for twkb::Polygon {
 
 impl<'a> FromSql<'a> for twkb::MultiPoint {
     accepts!(BYTEA);
-    fn from_sql(ty: &Type, raw: &[u8]) -> Result<Self, Box<Error + Sync + Send>> {
+    fn from_sql(ty: &Type, raw: &[u8]) -> Result<Self, Box<dyn Error + Sync + Send>> {
         let mut rdr = Cursor::new(raw);
         twkb::MultiPoint::read_twkb(&mut rdr)
             .map_err(|_| format!("cannot convert {} to MultiPoint", ty).into())
@@ -286,7 +286,7 @@ impl<'a> FromSql<'a> for twkb::MultiPoint {
 }
 
 impl<'a> FromSql<'a> for twkb::MultiLineString {
-    fn from_sql(ty: &Type, raw: &[u8]) -> Result<Self, Box<Error + Sync + Send>> {
+    fn from_sql(ty: &Type, raw: &[u8]) -> Result<Self, Box<dyn Error + Sync + Send>> {
         let mut rdr = Cursor::new(raw);
         twkb::MultiLineString::read_twkb(&mut rdr)
             .map_err(|_| format!("cannot convert {} to MultiLineString", ty).into())
@@ -296,7 +296,7 @@ impl<'a> FromSql<'a> for twkb::MultiLineString {
 }
 
 impl<'a> FromSql<'a> for twkb::MultiPolygon {
-    fn from_sql(ty: &Type, raw: &[u8]) -> Result<Self, Box<Error + Sync + Send>> {
+    fn from_sql(ty: &Type, raw: &[u8]) -> Result<Self, Box<dyn Error + Sync + Send>> {
         let mut rdr = Cursor::new(raw);
         twkb::MultiPolygon::read_twkb(&mut rdr)
             .map_err(|_| format!("cannot convert {} to MultiPolygon", ty).into())
@@ -653,7 +653,7 @@ mod tests {
         let result = or_panic!(conn.query("SELECT ST_AsTWKB('POINT EMPTY'::geometry)", &[]));
         let point = result.iter().map(|r| r.get::<_, twkb::Point>(0)).last().unwrap();
         assert_eq!(&format!("{:?}", point), "Point { x: NaN, y: NaN }");
-        let point = &point as &postgis::Point;
+        let point = &point as &dyn postgis::Point;
         assert!(point.x().is_nan());
 
         let result = or_panic!(conn.query("SELECT ST_AsTWKB(NULL::geometry(Point))", &[]));

--- a/src/postgis.rs
+++ b/src/postgis.rs
@@ -336,35 +336,35 @@ mod tests {
     #[ignore]
     #[cfg_attr(rustfmt, rustfmt_skip)]
     fn test_insert_point() {
-        let mut conn = connect();
-        or_panic!(conn.execute("CREATE TEMPORARY TABLE geomtests (geom geometry(Point))", &[]));
+        let mut client = connect();
+        or_panic!(client.execute("CREATE TEMPORARY TABLE geomtests (geom geometry(Point))", &[]));
 
         // 'POINT (10 -20)'
         let point = ewkb::Point { x: 10.0, y: -20.0, srid: None };
-        or_panic!(conn.execute("INSERT INTO geomtests (geom) VALUES ($1)", &[&point]));
-        let result = or_panic!(conn.query("SELECT geom=ST_GeomFromEWKT('POINT(10 -20)') FROM geomtests", &[]));
+        or_panic!(client.execute("INSERT INTO geomtests (geom) VALUES ($1)", &[&point]));
+        let result = or_panic!(client.query("SELECT geom=ST_GeomFromEWKT('POINT(10 -20)') FROM geomtests", &[]));
         assert!(result.iter().map(|r| r.get::<_, bool>(0)).last().unwrap());
-        or_panic!(conn.execute("TRUNCATE geomtests", &[]));
+        or_panic!(client.execute("TRUNCATE geomtests", &[]));
 
         // With SRID
         let point = ewkb::Point { x: 10.0, y: -20.0, srid: Some(4326) };
-        or_panic!(conn.execute("INSERT INTO geomtests (geom) VALUES ($1)", &[&point]));
-        let result = or_panic!(conn.query("SELECT geom=ST_GeomFromEWKT('SRID=4326;POINT(10 -20)') FROM geomtests", &[]));
+        or_panic!(client.execute("INSERT INTO geomtests (geom) VALUES ($1)", &[&point]));
+        let result = or_panic!(client.query("SELECT geom=ST_GeomFromEWKT('SRID=4326;POINT(10 -20)') FROM geomtests", &[]));
         assert!(result.iter().map(|r| r.get::<_, bool>(0)).last().unwrap());
-        or_panic!(conn.execute("TRUNCATE geomtests", &[]));
+        or_panic!(client.execute("TRUNCATE geomtests", &[]));
 
-        let mut conn = connect();
-        or_panic!(conn.execute("CREATE TEMPORARY TABLE geomtests (geom geometry(Point, 4326))", &[]));
+        let mut client = connect();
+        or_panic!(client.execute("CREATE TEMPORARY TABLE geomtests (geom geometry(Point, 4326))", &[]));
 
         let point = ewkb::Point { x: 10.0, y: -20.0, srid: Some(4326) };
-        or_panic!(conn.execute("INSERT INTO geomtests (geom) VALUES ($1)", &[&point]));
-        let result = or_panic!(conn.query("SELECT geom=ST_GeomFromEWKT('SRID=4326;POINT(10 -20)') FROM geomtests", &[]));
+        or_panic!(client.execute("INSERT INTO geomtests (geom) VALUES ($1)", &[&point]));
+        let result = or_panic!(client.query("SELECT geom=ST_GeomFromEWKT('SRID=4326;POINT(10 -20)') FROM geomtests", &[]));
         assert!(result.iter().map(|r| r.get::<_, bool>(0)).last().unwrap());
-        or_panic!(conn.execute("TRUNCATE geomtests", &[]));
+        or_panic!(client.execute("TRUNCATE geomtests", &[]));
 
         // Missing SRID
         let point = ewkb::Point { x: 10.0, y: -20.0, srid: None };
-        let result = conn.execute("INSERT INTO geomtests (geom) VALUES ($1)", &[&point]);
+        let result = client.execute("INSERT INTO geomtests (geom) VALUES ($1)", &[&point]);
         assert!(format!("{}", result.err().unwrap()).starts_with("db error"));
     }
 
@@ -372,51 +372,51 @@ mod tests {
     #[ignore]
     #[cfg_attr(rustfmt, rustfmt_skip)]
     fn test_insert_line() {
-        let mut conn = connect();
-        or_panic!(conn.execute("CREATE TEMPORARY TABLE geomtests (geom geometry(LineString))", &[]));
+        let mut client = connect();
+        or_panic!(client.execute("CREATE TEMPORARY TABLE geomtests (geom geometry(LineString))", &[]));
 
         let p = |x, y| ewkb::Point { x: x, y: y, srid: None };
         // 'LINESTRING (10 -20, -0 -0.5)'
         let line = ewkb::LineString {srid: None, points: vec![p(10.0, -20.0), p(0., -0.5)]};
-        or_panic!(conn.execute("INSERT INTO geomtests (geom) VALUES ($1)", &[&line]));
-        let result = or_panic!(conn.query("SELECT geom=ST_GeomFromEWKT('LINESTRING(10 -20, -0 -0.5)') FROM geomtests", &[]));
+        or_panic!(client.execute("INSERT INTO geomtests (geom) VALUES ($1)", &[&line]));
+        let result = or_panic!(client.query("SELECT geom=ST_GeomFromEWKT('LINESTRING(10 -20, -0 -0.5)') FROM geomtests", &[]));
         assert!(result.iter().map(|r| r.get::<_, bool>(0)).last().unwrap());
-        or_panic!(conn.execute("TRUNCATE geomtests", &[]));
+        or_panic!(client.execute("TRUNCATE geomtests", &[]));
 
-        let mut conn = connect();
-        or_panic!(conn.execute("CREATE TEMPORARY TABLE geomtests (geom geometry(LineString, 4326))", &[]));
+        let mut client = connect();
+        or_panic!(client.execute("CREATE TEMPORARY TABLE geomtests (geom geometry(LineString, 4326))", &[]));
 
         // 'SRID=4326;LINESTRING (10 -20, -0 -0.5)'
         let line = ewkb::LineString {srid: Some(4326), points: vec![p(10.0, -20.0), p(0., -0.5)]};
-        or_panic!(conn.execute("INSERT INTO geomtests (geom) VALUES ($1)", &[&line]));
-        let result = or_panic!(conn.query("SELECT geom=ST_GeomFromEWKT('SRID=4326;LINESTRING(10 -20, -0 -0.5)') FROM geomtests", &[]));
+        or_panic!(client.execute("INSERT INTO geomtests (geom) VALUES ($1)", &[&line]));
+        let result = or_panic!(client.query("SELECT geom=ST_GeomFromEWKT('SRID=4326;LINESTRING(10 -20, -0 -0.5)') FROM geomtests", &[]));
         assert!(result.iter().map(|r| r.get::<_, bool>(0)).last().unwrap());
-        or_panic!(conn.execute("TRUNCATE geomtests", &[]));
+        or_panic!(client.execute("TRUNCATE geomtests", &[]));
 
-        let mut conn = connect();
-        or_panic!(conn.execute("CREATE TEMPORARY TABLE geomtests (geom geometry(LineStringZ, 4326))", &[]));
+        let mut client = connect();
+        or_panic!(client.execute("CREATE TEMPORARY TABLE geomtests (geom geometry(LineStringZ, 4326))", &[]));
 
         let p = |x, y, z| ewkb::PointZ { x: x, y: y, z: z, srid: Some(4326) };
         // 'SRID=4326;LINESTRING (10 -20 100, -0 -0.5 101)'
         let line = ewkb::LineStringZ {srid: Some(4326), points: vec![p(10.0, -20.0, 100.0), p(0., -0.5, 101.0)]};
-        or_panic!(conn.execute("INSERT INTO geomtests (geom) VALUES ($1)", &[&line]));
-        let result = or_panic!(conn.query("SELECT geom=ST_GeomFromEWKT('SRID=4326;LINESTRING (10 -20 100, -0 -0.5 101)') FROM geomtests", &[]));
+        or_panic!(client.execute("INSERT INTO geomtests (geom) VALUES ($1)", &[&line]));
+        let result = or_panic!(client.query("SELECT geom=ST_GeomFromEWKT('SRID=4326;LINESTRING (10 -20 100, -0 -0.5 101)') FROM geomtests", &[]));
         assert!(result.iter().map(|r| r.get::<_, bool>(0)).last().unwrap());
-        or_panic!(conn.execute("TRUNCATE geomtests", &[]));
+        or_panic!(client.execute("TRUNCATE geomtests", &[]));
     }
 
     #[test]
     #[ignore]
     #[cfg_attr(rustfmt, rustfmt_skip)]
     fn test_insert_polygon() {
-        let mut conn = connect();
-        or_panic!(conn.execute("CREATE TEMPORARY TABLE geomtests (geom geometry(Polygon))", &[]));
+        let mut client = connect();
+        or_panic!(client.execute("CREATE TEMPORARY TABLE geomtests (geom geometry(Polygon))", &[]));
         let p = |x, y| ewkb::Point { x: x, y: y, srid: Some(4326) };
         // SELECT 'SRID=4326;POLYGON ((0 0, 2 0, 2 2, 0 2, 0 0))'::geometry
         let line = ewkb::LineString {srid: Some(4326), points: vec![p(0., 0.), p(2., 0.), p(2., 2.), p(0., 2.), p(0., 0.)]};
         let poly = ewkb::Polygon {srid: Some(4326), rings: vec![line]};
-        or_panic!(conn.execute("INSERT INTO geomtests (geom) VALUES ($1)", &[&poly]));
-        let result = or_panic!(conn.query("SELECT geom=ST_GeomFromEWKT('SRID=4326;POLYGON ((0 0, 2 0, 2 2, 0 2, 0 0))') FROM geomtests", &[]));
+        or_panic!(client.execute("INSERT INTO geomtests (geom) VALUES ($1)", &[&poly]));
+        let result = or_panic!(client.query("SELECT geom=ST_GeomFromEWKT('SRID=4326;POLYGON ((0 0, 2 0, 2 2, 0 2, 0 0))') FROM geomtests", &[]));
         assert!(result.iter().map(|r| r.get::<_, bool>(0)).last().unwrap());
     }
 
@@ -424,13 +424,13 @@ mod tests {
     #[ignore]
     #[cfg_attr(rustfmt, rustfmt_skip)]
     fn test_insert_multipoint() {
-        let mut conn = connect();
-        or_panic!(conn.execute("CREATE TEMPORARY TABLE geomtests (geom geometry(MultiPointZ))", &[]));
+        let mut client = connect();
+        or_panic!(client.execute("CREATE TEMPORARY TABLE geomtests (geom geometry(MultiPointZ))", &[]));
         let p = |x, y, z| ewkb::PointZ { x: x, y: y, z: z, srid: Some(4326) };
         // SELECT 'SRID=4326;MULTIPOINT ((10 -20 100), (0 -0.5 101))'::geometry
         let points = ewkb::MultiPointZ {srid: Some(4326), points: vec![p(10.0, -20.0, 100.0), p(0., -0.5, 101.0)]};
-        or_panic!(conn.execute("INSERT INTO geomtests (geom) VALUES ($1)", &[&points]));
-        let result = or_panic!(conn.query("SELECT geom=ST_GeomFromEWKT('SRID=4326;MULTIPOINT ((10 -20 100), (0 -0.5 101))') FROM geomtests", &[]));
+        or_panic!(client.execute("INSERT INTO geomtests (geom) VALUES ($1)", &[&points]));
+        let result = or_panic!(client.query("SELECT geom=ST_GeomFromEWKT('SRID=4326;MULTIPOINT ((10 -20 100), (0 -0.5 101))') FROM geomtests", &[]));
         assert!(result.iter().map(|r| r.get::<_, bool>(0)).last().unwrap());
     }
 
@@ -438,15 +438,15 @@ mod tests {
     #[ignore]
     #[cfg_attr(rustfmt, rustfmt_skip)]
     fn test_insert_multiline() {
-        let mut conn = connect();
-        or_panic!(conn.execute("CREATE TEMPORARY TABLE geomtests (geom geometry(MultiLineString))", &[]));
+        let mut client = connect();
+        or_panic!(client.execute("CREATE TEMPORARY TABLE geomtests (geom geometry(MultiLineString))", &[]));
         let p = |x, y| ewkb::Point { x: x, y: y, srid: Some(4326) };
         // SELECT 'SRID=4326;MULTILINESTRING ((10 -20, 0 -0.5), (0 0, 2 0))'::geometry
         let line1 = ewkb::LineString {srid: Some(4326), points: vec![p(10.0, -20.0), p(0., -0.5)]};
         let line2 = ewkb::LineString {srid: Some(4326), points: vec![p(0., 0.), p(2., 0.)]};
         let multiline = ewkb::MultiLineString {srid: Some(4326),lines: vec![line1, line2]};
-        or_panic!(conn.execute("INSERT INTO geomtests (geom) VALUES ($1)", &[&multiline]));
-        let result = or_panic!(conn.query("SELECT geom=ST_GeomFromEWKT('SRID=4326;MULTILINESTRING ((10 -20, 0 -0.5), (0 0, 2 0))') FROM geomtests", &[]));
+        or_panic!(client.execute("INSERT INTO geomtests (geom) VALUES ($1)", &[&multiline]));
+        let result = or_panic!(client.query("SELECT geom=ST_GeomFromEWKT('SRID=4326;MULTILINESTRING ((10 -20, 0 -0.5), (0 0, 2 0))') FROM geomtests", &[]));
         assert!(result.iter().map(|r| r.get::<_, bool>(0)).last().unwrap());
     }
 
@@ -454,8 +454,8 @@ mod tests {
     #[ignore]
     #[cfg_attr(rustfmt, rustfmt_skip)]
     fn test_insert_multipolygon() {
-        let mut conn = connect();
-        or_panic!(conn.execute("CREATE TEMPORARY TABLE geomtests (geom geometry(MultiPolygon))", &[]));
+        let mut client = connect();
+        or_panic!(client.execute("CREATE TEMPORARY TABLE geomtests (geom geometry(MultiPolygon))", &[]));
         let p = |x, y| ewkb::Point { x: x, y: y, srid: Some(4326) };
         // SELECT 'SRID=4326;MULTIPOLYGON (((0 0, 2 0, 2 2, 0 2, 0 0)), ((10 10, -2 10, -2 -2, 10 -2, 10 10)))'::geometry
         let line = ewkb::LineString {srid: Some(4326), points: vec![p(0., 0.), p(2., 0.), p(2., 2.), p(0., 2.), p(0., 0.)]};
@@ -463,8 +463,8 @@ mod tests {
         let line = ewkb::LineString {srid: Some(4326), points: vec![p(10., 10.), p(-2., 10.), p(-2., -2.), p(10., -2.), p(10., 10.)]};
         let poly2 = ewkb::Polygon {srid: Some(4326), rings: vec![line]};
         let multipoly = ewkb::MultiPolygon {srid: Some(4326), polygons: vec![poly1, poly2]};
-        or_panic!(conn.execute("INSERT INTO geomtests (geom) VALUES ($1)", &[&multipoly]));
-        let result = or_panic!(conn.query("SELECT geom=ST_GeomFromEWKT('SRID=4326;MULTIPOLYGON (((0 0, 2 0, 2 2, 0 2, 0 0)), ((10 10, -2 10, -2 -2, 10 -2, 10 10)))') FROM geomtests", &[]));
+        or_panic!(client.execute("INSERT INTO geomtests (geom) VALUES ($1)", &[&multipoly]));
+        let result = or_panic!(client.query("SELECT geom=ST_GeomFromEWKT('SRID=4326;MULTIPOLYGON (((0 0, 2 0, 2 2, 0 2, 0 0)), ((10 10, -2 10, -2 -2, 10 -2, 10 10)))') FROM geomtests", &[]));
         assert!(result.iter().map(|r| r.get::<_, bool>(0)).last().unwrap());
     }
 
@@ -472,8 +472,8 @@ mod tests {
     #[ignore]
     #[cfg_attr(rustfmt, rustfmt_skip)]
     fn test_insert_geometry() {
-        let mut conn = connect();
-        or_panic!(conn.execute("CREATE TEMPORARY TABLE geomtests (geom geometry)", &[]));
+        let mut client = connect();
+        or_panic!(client.execute("CREATE TEMPORARY TABLE geomtests (geom geometry)", &[]));
         let p = |x, y| ewkb::Point { x: x, y: y, srid: Some(4326) };
         // SELECT 'SRID=4326;MULTIPOLYGON (((0 0, 2 0, 2 2, 0 2, 0 0)), ((10 10, -2 10, -2 -2, 10 -2, 10 10)))'::geometry
         let multipoly = {
@@ -484,8 +484,8 @@ mod tests {
             ewkb::MultiPolygon {srid: Some(4326), polygons: vec![poly1, poly2]}
         };
         let geometry = ewkb::GeometryT::MultiPolygon(multipoly);
-        or_panic!(conn.execute("INSERT INTO geomtests (geom) VALUES ($1)", &[&geometry]));
-        let result = or_panic!(conn.query("SELECT geom=ST_GeomFromEWKT('SRID=4326;MULTIPOLYGON (((0 0, 2 0, 2 2, 0 2, 0 0)), ((10 10, -2 10, -2 -2, 10 -2, 10 10)))') FROM geomtests", &[]));
+        or_panic!(client.execute("INSERT INTO geomtests (geom) VALUES ($1)", &[&geometry]));
+        let result = or_panic!(client.query("SELECT geom=ST_GeomFromEWKT('SRID=4326;MULTIPOLYGON (((0 0, 2 0, 2 2, 0 2, 0 0)), ((10 10, -2 10, -2 -2, 10 -2, 10 10)))') FROM geomtests", &[]));
         assert!(result.iter().map(|r| r.get::<_, bool>(0)).last().unwrap());
     }
 
@@ -493,8 +493,8 @@ mod tests {
     #[ignore]
     #[cfg_attr(rustfmt, rustfmt_skip)]
     fn test_insert_geometrycollection() {
-        let mut conn = connect();
-        or_panic!(conn.execute("CREATE TEMPORARY TABLE geomtests (geom geometry(GeometryCollection))", &[]));
+        let mut client = connect();
+        or_panic!(client.execute("CREATE TEMPORARY TABLE geomtests (geom geometry(GeometryCollection))", &[]));
         let p = |x, y| ewkb::Point { x: x, y: y, srid: Some(4326) };
         // SELECT 'SRID=4326;LINESTRING (10 -20, -0 -0.5)'
         let line = ewkb::LineString {srid: Some(4326), points: vec![p(10.0, -20.0), p(0., -0.5)]};
@@ -514,8 +514,8 @@ mod tests {
                 ewkb::GeometryT::MultiPolygon(multipoly),
             ],
         };
-        or_panic!(conn.execute("INSERT INTO geomtests (geom) VALUES ($1)", &[&collection]));
-        let result = or_panic!(conn.query("SELECT geom=ST_GeomFromEWKT('SRID=4326;GEOMETRYCOLLECTION (LINESTRING (10 -20,0 -0.5), MULTIPOLYGON (((0 0,2 0,2 2,0 2,0 0)),((10 10,-2 10,-2 -2,10 -2,10 10))))') FROM geomtests", &[]));
+        or_panic!(client.execute("INSERT INTO geomtests (geom) VALUES ($1)", &[&collection]));
+        let result = or_panic!(client.query("SELECT geom=ST_GeomFromEWKT('SRID=4326;GEOMETRYCOLLECTION (LINESTRING (10 -20,0 -0.5), MULTIPOLYGON (((0 0,2 0,2 2,0 2,0 0)),((10 10,-2 10,-2 -2,10 -2,10 10))))') FROM geomtests", &[]));
         assert!(result.iter().map(|r| r.get::<_, bool>(0)).last().unwrap());
     }
 
@@ -523,24 +523,24 @@ mod tests {
     #[ignore]
     #[cfg_attr(rustfmt, rustfmt_skip)]
     fn test_select_point() {
-        let mut conn = connect();
-        let result = or_panic!(conn.query("SELECT ('POINT(10 -20)')::geometry", &[]));
+        let mut client = connect();
+        let result = or_panic!(client.query("SELECT ('POINT(10 -20)')::geometry", &[]));
         let point = result.iter().map(|r| r.get::<_, ewkb::Point>(0)).last().unwrap();
         assert_eq!(point, ewkb::Point { x: 10.0, y: -20.0, srid: None });
 
-        let result = or_panic!(conn.query("SELECT 'SRID=4326;POINT(10 -20)'::geometry", &[]));
+        let result = or_panic!(client.query("SELECT 'SRID=4326;POINT(10 -20)'::geometry", &[]));
         let point = result.iter().map(|r| r.get::<_, ewkb::Point>(0)).last().unwrap();
         assert_eq!(point, ewkb::Point { x: 10.0, y: -20.0, srid: Some(4326) });
 
-        let result = or_panic!(conn.query("SELECT 'SRID=4326;POINT(10 -20 99)'::geometry", &[]));
+        let result = or_panic!(client.query("SELECT 'SRID=4326;POINT(10 -20 99)'::geometry", &[]));
         let point = result.iter().map(|r| r.get::<_, ewkb::PointZ>(0)).last().unwrap();
         assert_eq!(point, ewkb::PointZ { x: 10.0, y: -20.0, z: 99.0, srid: Some(4326) });
 
-        let result = or_panic!(conn.query("SELECT 'POINT EMPTY'::geometry", &[]));
+        let result = or_panic!(client.query("SELECT 'POINT EMPTY'::geometry", &[]));
         let point = result.iter().map(|r| r.get::<_, ewkb::Point>(0)).last().unwrap();
         assert_eq!(&format!("{:?}", point), "Point { x: NaN, y: NaN, srid: None }");
 
-        let result = or_panic!(conn.query("SELECT NULL::geometry(Point)", &[]));
+        let result = or_panic!(client.query("SELECT NULL::geometry(Point)", &[]));
         let point = result.iter().map(|r| r.try_get::<_, ewkb::Point>(0)).last().unwrap();
         assert_eq!(&format!("{:?}", point), "Err(Error { kind: FromSql(0), cause: Some(WasNull) })");
     }
@@ -549,18 +549,18 @@ mod tests {
     #[ignore]
     #[cfg_attr(rustfmt, rustfmt_skip)]
     fn test_select_line() {
-        let mut conn = connect();
+        let mut client = connect();
         let p = |x, y| ewkb::Point { x: x, y: y, srid: None };
-        let result = or_panic!(conn.query("SELECT ('LINESTRING (10 -20, -0 -0.5)')::geometry", &[]));
+        let result = or_panic!(client.query("SELECT ('LINESTRING (10 -20, -0 -0.5)')::geometry", &[]));
         let line = result.iter().map(|r| r.get::<_, ewkb::LineString>(0)).last().unwrap();
         assert_eq!(line, ewkb::LineString {srid: None, points: vec![p(10.0, -20.0), p(0., -0.5)]});
 
         let p = |x, y| ewkb::Point { x: x, y: y, srid: Some(4326) };
-        let result = or_panic!(conn.query("SELECT ('SRID=4326;LINESTRING (10 -20, -0 -0.5)')::geometry", &[]));
+        let result = or_panic!(client.query("SELECT ('SRID=4326;LINESTRING (10 -20, -0 -0.5)')::geometry", &[]));
         let line = result.iter().map(|r| r.get::<_, ewkb::LineString>(0)).last().unwrap();
         assert_eq!(line, ewkb::LineString {srid: Some(4326), points: vec![p(10.0, -20.0), p(0., -0.5)]});
 
-        let result = or_panic!(conn.query("SELECT 'LINESTRING EMPTY'::geometry", &[]));
+        let result = or_panic!(client.query("SELECT 'LINESTRING EMPTY'::geometry", &[]));
         let line = result.iter().map(|r| r.get::<_, ewkb::LineString>(0)).last().unwrap();
         assert_eq!(&format!("{:?}", line), "LineStringT { points: [], srid: None }");
     }
@@ -569,8 +569,8 @@ mod tests {
     #[ignore]
     #[cfg_attr(rustfmt, rustfmt_skip)]
     fn test_select_polygon() {
-        let mut conn = connect();
-        let result = or_panic!(conn.query("SELECT 'SRID=4326;POLYGON ((0 0, 2 0, 2 2, 0 2, 0 0))'::geometry", &[]));
+        let mut client = connect();
+        let result = or_panic!(client.query("SELECT 'SRID=4326;POLYGON ((0 0, 2 0, 2 2, 0 2, 0 0))'::geometry", &[]));
         let poly = result.iter().map(|r| r.get::<_, ewkb::Polygon>(0)).last().unwrap();
         assert_eq!(format!("{:.0?}", poly), "PolygonT { rings: [LineStringT { points: [Point { x: 0, y: 0, srid: Some(4326) }, Point { x: 2, y: 0, srid: Some(4326) }, Point { x: 2, y: 2, srid: Some(4326) }, Point { x: 0, y: 2, srid: Some(4326) }, Point { x: 0, y: 0, srid: Some(4326) }], srid: Some(4326) }], srid: Some(4326) }");
     }
@@ -579,8 +579,8 @@ mod tests {
     #[ignore]
     #[cfg_attr(rustfmt, rustfmt_skip)]
     fn test_select_multipoint() {
-        let mut conn = connect();
-        let result = or_panic!(conn.query("SELECT 'SRID=4326;MULTIPOINT ((10 -20 100), (0 -0.5 101))'::geometry", &[]));
+        let mut client = connect();
+        let result = or_panic!(client.query("SELECT 'SRID=4326;MULTIPOINT ((10 -20 100), (0 -0.5 101))'::geometry", &[]));
         let points = result.iter().map(|r| r.get::<_, ewkb::MultiPointZ>(0)).last().unwrap();
         assert_eq!(format!("{:.1?}", points), "MultiPointT { points: [PointZ { x: 10.0, y: -20.0, z: 100.0, srid: None }, PointZ { x: 0.0, y: -0.5, z: 101.0, srid: None }], srid: Some(4326) }");
     }
@@ -589,8 +589,8 @@ mod tests {
     #[ignore]
     #[cfg_attr(rustfmt, rustfmt_skip)]
     fn test_select_multiline() {
-        let mut conn = connect();
-        let result = or_panic!(conn.query("SELECT 'SRID=4326;MULTILINESTRING ((10 -20, 0 -0.5), (0 0, 2 0))'::geometry", &[]));
+        let mut client = connect();
+        let result = or_panic!(client.query("SELECT 'SRID=4326;MULTILINESTRING ((10 -20, 0 -0.5), (0 0, 2 0))'::geometry", &[]));
         let multiline = result.iter().map(|r| r.get::<_, ewkb::MultiLineString>(0)).last().unwrap();
         assert_eq!(format!("{:.1?}", multiline), "MultiLineStringT { lines: [LineStringT { points: [Point { x: 10.0, y: -20.0, srid: None }, Point { x: 0.0, y: -0.5, srid: None }], srid: None }, LineStringT { points: [Point { x: 0.0, y: 0.0, srid: None }, Point { x: 2.0, y: 0.0, srid: None }], srid: None }], srid: Some(4326) }");
     }
@@ -599,8 +599,8 @@ mod tests {
     #[ignore]
     #[cfg_attr(rustfmt, rustfmt_skip)]
     fn test_select_multipolygon() {
-        let mut conn = connect();
-        let result = or_panic!(conn.query("SELECT 'SRID=4326;MULTIPOLYGON (((0 0, 2 0, 2 2, 0 2, 0 0)), ((10 10, -2 10, -2 -2, 10 -2, 10 10)))'::geometry", &[]));
+        let mut client = connect();
+        let result = or_panic!(client.query("SELECT 'SRID=4326;MULTIPOLYGON (((0 0, 2 0, 2 2, 0 2, 0 0)), ((10 10, -2 10, -2 -2, 10 -2, 10 10)))'::geometry", &[]));
         let multipoly = result.iter().map(|r| r.get::<_, ewkb::MultiPolygon>(0)).last().unwrap();
         assert_eq!(format!("{:.0?}", multipoly), "MultiPolygonT { polygons: [PolygonT { rings: [LineStringT { points: [Point { x: 0, y: 0, srid: None }, Point { x: 2, y: 0, srid: None }, Point { x: 2, y: 2, srid: None }, Point { x: 0, y: 2, srid: None }, Point { x: 0, y: 0, srid: None }], srid: None }], srid: None }, PolygonT { rings: [LineStringT { points: [Point { x: 10, y: 10, srid: None }, Point { x: -2, y: 10, srid: None }, Point { x: -2, y: -2, srid: None }, Point { x: 10, y: -2, srid: None }, Point { x: 10, y: 10, srid: None }], srid: None }], srid: None }], srid: Some(4326) }");
     }
@@ -609,8 +609,8 @@ mod tests {
     #[ignore]
     #[cfg_attr(rustfmt, rustfmt_skip)]
     fn test_select_geometrycollection() {
-        let mut conn = connect();
-        let result = or_panic!(conn.query("SELECT 'GeometryCollection(POINT (10 10),POINT (30 30),LINESTRING (15 15, 20 20))'::geometry", &[]));
+        let mut client = connect();
+        let result = or_panic!(client.query("SELECT 'GeometryCollection(POINT (10 10),POINT (30 30),LINESTRING (15 15, 20 20))'::geometry", &[]));
         let geom = result.iter().map(|r| r.get::<_, ewkb::GeometryCollection>(0)).last().unwrap();
         assert_eq!(format!("{:.0?}", geom), "GeometryCollectionT { geometries: [Point(Point { x: 10, y: 10, srid: None }), Point(Point { x: 30, y: 30, srid: None }), LineString(LineStringT { points: [Point { x: 15, y: 15, srid: None }, Point { x: 20, y: 20, srid: None }], srid: None })], srid: None }");
     }
@@ -619,10 +619,10 @@ mod tests {
     #[ignore]
     #[cfg_attr(rustfmt, rustfmt_skip)]
     fn test_select_geometry() {
-        let mut conn = connect();
-        or_panic!(conn.execute("CREATE TEMPORARY TABLE geomtests (geom geometry)", &[]));
-        or_panic!(conn.execute("INSERT INTO geomtests VALUES('SRID=4326;POINT(10 -20 99)'::geometry)", &[]));
-        let result = or_panic!(conn.query("SELECT geom FROM geomtests", &[]));
+        let mut client = connect();
+        or_panic!(client.execute("CREATE TEMPORARY TABLE geomtests (geom geometry)", &[]));
+        or_panic!(client.execute("INSERT INTO geomtests VALUES('SRID=4326;POINT(10 -20 99)'::geometry)", &[]));
+        let result = or_panic!(client.query("SELECT geom FROM geomtests", &[]));
         let geom = result.iter().map(|r| r.get::<_, ewkb::GeometryZ>(0)).last().unwrap();
         assert_eq!(format!("{:.0?}", geom), "Point(PointZ { x: 10, y: -20, z: 99, srid: Some(4326) })");
     }
@@ -631,8 +631,8 @@ mod tests {
     #[ignore]
     #[cfg_attr(rustfmt, rustfmt_skip)]
     fn test_select_type_error() {
-        let mut conn = connect();
-        let result = or_panic!(conn.query("SELECT ('LINESTRING (10 -20, -0 -0.5)')::geometry", &[]));
+        let mut client = connect();
+        let result = or_panic!(client.query("SELECT ('LINESTRING (10 -20, -0 -0.5)')::geometry", &[]));
         let poly = result.iter().map(|r| r.try_get::<_, ewkb::Polygon>(0)).last().unwrap();
         assert_eq!(format!("{:?}", poly), "Err(Error { kind: FromSql(0), cause: Some(\"cannot convert geometry to PolygonT\") })");
     }
@@ -641,26 +641,26 @@ mod tests {
     #[ignore]
     #[cfg_attr(rustfmt, rustfmt_skip)]
     fn test_twkb() {
-        let mut conn = connect();
-        let result = or_panic!(conn.query("SELECT ST_AsTWKB('POINT(10 -20)'::geometry)", &[]));
+        let mut client = connect();
+        let result = or_panic!(client.query("SELECT ST_AsTWKB('POINT(10 -20)'::geometry)", &[]));
         let point = result.iter().map(|r| r.get::<_, twkb::Point>(0)).last().unwrap();
         assert_eq!(point, twkb::Point {x: 10.0, y: -20.0});
 
-        let result = or_panic!(conn.query("SELECT ST_AsTWKB('SRID=4326;POINT(10 -20)'::geometry)", &[]));
+        let result = or_panic!(client.query("SELECT ST_AsTWKB('SRID=4326;POINT(10 -20)'::geometry)", &[]));
         let point = result.iter().map(|r| r.get::<_, twkb::Point>(0)).last().unwrap();
         assert_eq!(point, twkb::Point {x: 10.0, y: -20.0});
 
-        let result = or_panic!(conn.query("SELECT ST_AsTWKB('POINT EMPTY'::geometry)", &[]));
+        let result = or_panic!(client.query("SELECT ST_AsTWKB('POINT EMPTY'::geometry)", &[]));
         let point = result.iter().map(|r| r.get::<_, twkb::Point>(0)).last().unwrap();
         assert_eq!(&format!("{:?}", point), "Point { x: NaN, y: NaN }");
         let point = &point as &dyn postgis::Point;
         assert!(point.x().is_nan());
 
-        let result = or_panic!(conn.query("SELECT ST_AsTWKB(NULL::geometry(Point))", &[]));
+        let result = or_panic!(client.query("SELECT ST_AsTWKB(NULL::geometry(Point))", &[]));
         let point = result.iter().map(|r| r.try_get::<_, twkb::Point>(0)).last().unwrap();
         assert_eq!(&format!("{:?}", point), "Err(Error { kind: FromSql(0), cause: Some(WasNull) })");
 
-        let result = or_panic!(conn.query("SELECT ST_AsTWKB('LINESTRING (10 -20, -0 -0.5)'::geometry, 1)", &[]));
+        let result = or_panic!(client.query("SELECT ST_AsTWKB('LINESTRING (10 -20, -0 -0.5)'::geometry, 1)", &[]));
         let line = result.iter().map(|r| r.get::<_, twkb::LineString>(0)).last().unwrap();
         assert_eq!(&format!("{:.1?}", line), "LineString { points: [Point { x: 10.0, y: -20.0 }, Point { x: 0.0, y: -0.5 }] }");
     }
@@ -669,27 +669,27 @@ mod tests {
     #[ignore]
     #[cfg_attr(rustfmt, rustfmt_skip)]
     fn test_twkb_insert() {
-        let mut conn = connect();
-        or_panic!(conn.execute("CREATE TEMPORARY TABLE geomtests (geom geometry(Point))", &[]));
+        let mut client = connect();
+        or_panic!(client.execute("CREATE TEMPORARY TABLE geomtests (geom geometry(Point))", &[]));
 
-        let result = or_panic!(conn.query("SELECT ST_AsTWKB('POINT(10 -20)'::geometry)", &[]));
+        let result = or_panic!(client.query("SELECT ST_AsTWKB('POINT(10 -20)'::geometry)", &[]));
         let point = result.iter().map(|r| r.get::<_, twkb::Point>(0)).last().unwrap();
 
-        or_panic!(conn.execute("INSERT INTO geomtests (geom) VALUES ($1)", &[&point.as_ewkb()]));
-        let result = or_panic!(conn.query("SELECT geom=ST_GeomFromEWKT('POINT(10 -20)') FROM geomtests", &[]));
+        or_panic!(client.execute("INSERT INTO geomtests (geom) VALUES ($1)", &[&point.as_ewkb()]));
+        let result = or_panic!(client.query("SELECT geom=ST_GeomFromEWKT('POINT(10 -20)') FROM geomtests", &[]));
         assert!(result.iter().map(|r| r.get::<_, bool>(0)).last().unwrap());
-        or_panic!(conn.execute("TRUNCATE geomtests", &[]));
+        or_panic!(client.execute("TRUNCATE geomtests", &[]));
 
-        let mut conn = connect();
-        or_panic!(conn.execute("CREATE TEMPORARY TABLE geomtests (geom geometry(LineString))", &[]));
+        let mut client = connect();
+        or_panic!(client.execute("CREATE TEMPORARY TABLE geomtests (geom geometry(LineString))", &[]));
 
-        let result = or_panic!(conn.query("SELECT ST_AsTWKB('LINESTRING (10 -20, -0 -0.5)'::geometry, 1)", &[]));
+        let result = or_panic!(client.query("SELECT ST_AsTWKB('LINESTRING (10 -20, -0 -0.5)'::geometry, 1)", &[]));
         let line = result.iter().map(|r| r.get::<_, twkb::LineString>(0)).last().unwrap();
 
-        or_panic!(conn.execute("INSERT INTO geomtests (geom) VALUES ($1)", &[&line.as_ewkb()]));
-        let result = or_panic!(conn.query("SELECT geom=ST_GeomFromEWKT('LINESTRING (10 -20, -0 -0.5)') FROM geomtests", &[]));
+        or_panic!(client.execute("INSERT INTO geomtests (geom) VALUES ($1)", &[&line.as_ewkb()]));
+        let result = or_panic!(client.query("SELECT geom=ST_GeomFromEWKT('LINESTRING (10 -20, -0 -0.5)') FROM geomtests", &[]));
         assert!(result.iter().map(|r| r.get::<_, bool>(0)).last().unwrap());
-        or_panic!(conn.execute("TRUNCATE geomtests", &[]));
+        or_panic!(client.execute("TRUNCATE geomtests", &[]));
     }
 
     #[test]
@@ -708,20 +708,20 @@ mod tests {
                 types::LineString,
                 twkb
             };
-            let mut conn = connect();
-            or_panic!(conn.execute("CREATE TEMPORARY TABLE busline (route geometry(LineString))", &[]));
-            or_panic!(conn.execute("CREATE TEMPORARY TABLE stops (stop geometry(Point))", &[]));
-            or_panic!(conn.execute("INSERT INTO busline (route) VALUES ('LINESTRING(10 -20, -0 -0.5)'::geometry)", &[]));
+            let mut client = connect();
+            or_panic!(client.execute("CREATE TEMPORARY TABLE busline (route geometry(LineString))", &[]));
+            or_panic!(client.execute("CREATE TEMPORARY TABLE stops (stop geometry(Point))", &[]));
+            or_panic!(client.execute("INSERT INTO busline (route) VALUES ('LINESTRING(10 -20, -0 -0.5)'::geometry)", &[]));
             //
 
             // conn ....
-            for row in &conn.query("SELECT * FROM busline", &[]).unwrap() {
+            for row in &client.query("SELECT * FROM busline", &[]).unwrap() {
                 let route: ewkb::LineString = row.get("route");
                 let last_stop = route.points().last().unwrap();
-                let _ = conn.execute("INSERT INTO stops (stop) VALUES ($1)", &[&last_stop]);
+                let _ = client.execute("INSERT INTO stops (stop) VALUES ($1)", &[&last_stop]);
             }
 
-            for row in &conn.query("SELECT * FROM busline", &[]).unwrap() {
+            for row in &client.query("SELECT * FROM busline", &[]).unwrap() {
                 let route = row.try_get::<_, Option<ewkb::LineString>>("route");
                 match route {
                     Ok(Some(geom)) => { println!("{:?}", geom) }
@@ -732,10 +732,10 @@ mod tests {
 
         //use postgis::twkb;
 
-            for row in &conn.query("SELECT ST_AsTWKB(route) FROM busline", &[]).unwrap() {
+            for row in &client.query("SELECT ST_AsTWKB(route) FROM busline", &[]).unwrap() {
                 let route: twkb::LineString = row.get(0);
                 let last_stop = route.points().last().unwrap();
-                let _ = conn.execute("INSERT INTO stops (stop) VALUES ($1)", &[&last_stop.as_ewkb()]);
+                let _ = client.execute("INSERT INTO stops (stop) VALUES ($1)", &[&last_stop.as_ewkb()]);
             }
         }
 

--- a/src/postgis.rs
+++ b/src/postgis.rs
@@ -2,29 +2,33 @@
 // Copyright (c) ShuYu Wang <andelf@gmail.com>, Feather Workshop and Pirmin Kalberer. All rights reserved.
 //
 
-use types::{LineString, Point, Polygon};
-use ewkb::{self, AsEwkbGeometry, AsEwkbGeometryCollection, AsEwkbLineString,
-           AsEwkbMultiLineString, AsEwkbMultiPoint, AsEwkbMultiPolygon, AsEwkbPoint,
-           AsEwkbPolygon, EwkbRead, EwkbWrite};
-use twkb::{self, TwkbGeom};
-use std::io::Cursor;
-use postgres::types::{FromSql, IsNull, ToSql, Type, BYTEA};
+use crate::{
+    ewkb::{
+        self, AsEwkbGeometry, AsEwkbGeometryCollection, AsEwkbLineString, AsEwkbMultiLineString,
+        AsEwkbMultiPoint, AsEwkbMultiPolygon, AsEwkbPoint, AsEwkbPolygon, EwkbRead, EwkbWrite,
+    },
+    twkb::{self, TwkbGeom},
+    types::{LineString, Point, Polygon},
+};
+use bytes::{buf::ext::BufMutExt, BytesMut};
+use postgres::types::{accepts, to_sql_checked, FromSql, IsNull, ToSql, Type};
 use std::error::Error;
+use std::io::Cursor;
 
 macro_rules! accepts_geography {
-    () => (
+    () => {
         fn accepts(ty: &Type) -> bool {
             match ty.name() {
                 "geography" | "geometry" => true,
                 _ => false,
             }
         }
-    )
+    };
 }
 
 impl<'a> ToSql for ewkb::EwkbPoint<'a> {
-    fn to_sql(&self, _: &Type, out: &mut Vec<u8>) -> Result<IsNull, Box<Error + Sync + Send>> {
-        self.write_ewkb(out)?;
+    fn to_sql(&self, _: &Type, out: &mut BytesMut) -> Result<IsNull, Box<Error + Sync + Send>> {
+        self.write_ewkb(&mut out.writer())?;
         Ok(IsNull::No)
     }
 
@@ -33,26 +37,31 @@ impl<'a> ToSql for ewkb::EwkbPoint<'a> {
 }
 
 macro_rules! impl_sql_for_point_type {
-    ($ptype:ident) => (
-        impl FromSql for ewkb::$ptype {
+    ($ptype:ident) => {
+        impl<'a> FromSql<'a> for ewkb::$ptype {
             fn from_sql(ty: &Type, raw: &[u8]) -> Result<Self, Box<Error + Sync + Send>> {
                 let mut rdr = Cursor::new(raw);
-                ewkb::$ptype::read_ewkb(&mut rdr).map_err(|_| format!("cannot convert {} to {}", ty, stringify!($ptype)).into())
+                ewkb::$ptype::read_ewkb(&mut rdr)
+                    .map_err(|_| format!("cannot convert {} to {}", ty, stringify!($ptype)).into())
             }
 
             accepts_geography!();
         }
 
         impl ToSql for ewkb::$ptype {
-            fn to_sql(&self, _: &Type, out: &mut Vec<u8>) -> Result<IsNull, Box<Error + Sync + Send>> {
-                self.as_ewkb().write_ewkb(out)?;
+            fn to_sql(
+                &self,
+                _: &Type,
+                out: &mut BytesMut,
+            ) -> Result<IsNull, Box<Error + Sync + Send>> {
+                self.as_ewkb().write_ewkb(&mut out.writer())?;
                 Ok(IsNull::No)
             }
 
             to_sql_checked!();
             accepts_geography!();
         }
-    )
+    };
 }
 
 impl_sql_for_point_type!(Point);
@@ -61,30 +70,38 @@ impl_sql_for_point_type!(PointM);
 impl_sql_for_point_type!(PointZM);
 
 macro_rules! impl_sql_for_geom_type {
-    ($geotype:ident) => (
-        impl<'a, T> FromSql for ewkb::$geotype<T>
-            where T: 'a + Point + EwkbRead
+    ($geotype:ident) => {
+        impl<'a, T> FromSql<'a> for ewkb::$geotype<T>
+        where
+            T: 'a + Point + EwkbRead,
         {
             fn from_sql(ty: &Type, raw: &[u8]) -> Result<Self, Box<Error + Sync + Send>> {
                 let mut rdr = Cursor::new(raw);
-                ewkb::$geotype::<T>::read_ewkb(&mut rdr).map_err(|_| format!("cannot convert {} to {}", ty, stringify!($geotype)).into())
+                ewkb::$geotype::<T>::read_ewkb(&mut rdr).map_err(|_| {
+                    format!("cannot convert {} to {}", ty, stringify!($geotype)).into()
+                })
             }
 
             accepts_geography!();
         }
 
         impl<'a, T> ToSql for ewkb::$geotype<T>
-            where T: 'a + Point + EwkbRead
+        where
+            T: 'a + Point + EwkbRead,
         {
-            fn to_sql(&self, _: &Type, out: &mut Vec<u8>) -> Result<IsNull, Box<Error + Sync + Send>> {
-                self.as_ewkb().write_ewkb(out)?;
+            fn to_sql(
+                &self,
+                _: &Type,
+                out: &mut BytesMut,
+            ) -> Result<IsNull, Box<Error + Sync + Send>> {
+                self.as_ewkb().write_ewkb(&mut out.writer())?;
                 Ok(IsNull::No)
             }
 
             to_sql_checked!();
             accepts_geography!();
         }
-    )
+    };
 }
 
 impl_sql_for_geom_type!(LineStringT);
@@ -94,53 +111,68 @@ impl_sql_for_geom_type!(MultiLineStringT);
 impl_sql_for_geom_type!(MultiPolygonT);
 
 macro_rules! impl_sql_for_ewkb_type {
-    ($ewkbtype:ident contains points) => (
+    ($ewkbtype:ident contains points) => {
         impl<'a, T, I> ToSql for ewkb::$ewkbtype<'a, T, I>
-            where T: 'a + Point,
-                  I: 'a + Iterator<Item=&'a T> + ExactSizeIterator<Item=&'a T>
+        where
+            T: 'a + Point,
+            I: 'a + Iterator<Item = &'a T> + ExactSizeIterator<Item = &'a T>,
         {
-            fn to_sql(&self, _: &Type, out: &mut Vec<u8>) -> Result<IsNull, Box<Error + Sync + Send>> {
-                self.write_ewkb(out)?;
+            fn to_sql(
+                &self,
+                _: &Type,
+                out: &mut BytesMut,
+            ) -> Result<IsNull, Box<Error + Sync + Send>> {
+                self.write_ewkb(&mut out.writer())?;
                 Ok(IsNull::No)
             }
 
             to_sql_checked!();
             accepts_geography!();
         }
-    );
-    ($ewkbtype:ident contains $itemtypetrait:ident) => (
+    };
+    ($ewkbtype:ident contains $itemtypetrait:ident) => {
         impl<'a, P, I, T, J> ToSql for ewkb::$ewkbtype<'a, P, I, T, J>
-            where P: 'a + Point,
-                  I: 'a + Iterator<Item=&'a P> + ExactSizeIterator<Item=&'a P>,
-                  T: 'a + $itemtypetrait<'a, ItemType=P, Iter=I>,
-                  J: 'a + Iterator<Item=&'a T> + ExactSizeIterator<Item=&'a T>
+        where
+            P: 'a + Point,
+            I: 'a + Iterator<Item = &'a P> + ExactSizeIterator<Item = &'a P>,
+            T: 'a + $itemtypetrait<'a, ItemType = P, Iter = I>,
+            J: 'a + Iterator<Item = &'a T> + ExactSizeIterator<Item = &'a T>,
         {
-            fn to_sql(&self, _: &Type, out: &mut Vec<u8>) -> Result<IsNull, Box<Error + Sync + Send>> {
-                self.write_ewkb(out)?;
+            fn to_sql(
+                &self,
+                _: &Type,
+                out: &mut BytesMut,
+            ) -> Result<IsNull, Box<Error + Sync + Send>> {
+                self.write_ewkb(&mut out.writer())?;
                 Ok(IsNull::No)
             }
 
             to_sql_checked!();
             accepts_geography!();
         }
-    );
-    (multipoly $ewkbtype:ident contains $itemtypetrait:ident) => (
+    };
+    (multipoly $ewkbtype:ident contains $itemtypetrait:ident) => {
         impl<'a, P, I, L, K, T, J> ToSql for ewkb::$ewkbtype<'a, P, I, L, K, T, J>
-            where P: 'a + Point,
-                  I: 'a + Iterator<Item=&'a P> + ExactSizeIterator<Item=&'a P>,
-                  L: 'a + LineString<'a, ItemType=P, Iter=I>,
-                  K: 'a + Iterator<Item=&'a L> + ExactSizeIterator<Item=&'a L>,
-                  T: 'a + $itemtypetrait<'a, ItemType=L, Iter=K>,
-                  J: 'a + Iterator<Item=&'a T> + ExactSizeIterator<Item=&'a T>
+        where
+            P: 'a + Point,
+            I: 'a + Iterator<Item = &'a P> + ExactSizeIterator<Item = &'a P>,
+            L: 'a + LineString<'a, ItemType = P, Iter = I>,
+            K: 'a + Iterator<Item = &'a L> + ExactSizeIterator<Item = &'a L>,
+            T: 'a + $itemtypetrait<'a, ItemType = L, Iter = K>,
+            J: 'a + Iterator<Item = &'a T> + ExactSizeIterator<Item = &'a T>,
         {
             to_sql_checked!();
             accepts_geography!();
-            fn to_sql(&self, _: &Type, out: &mut Vec<u8>) -> Result<IsNull, Box<Error + Sync + Send>> {
-                self.write_ewkb(out)?;
+            fn to_sql(
+                &self,
+                _: &Type,
+                out: &mut BytesMut,
+            ) -> Result<IsNull, Box<Error + Sync + Send>> {
+                self.write_ewkb(&mut out.writer())?;
                 Ok(IsNull::No)
             }
         }
-    )
+    };
 }
 
 impl_sql_for_ewkb_type!(EwkbLineString contains points);
@@ -149,7 +181,7 @@ impl_sql_for_ewkb_type!(EwkbMultiPoint contains points);
 impl_sql_for_ewkb_type!(EwkbMultiLineString contains LineString);
 impl_sql_for_ewkb_type!(multipoly EwkbMultiPolygon contains Polygon);
 
-impl<P> FromSql for ewkb::GeometryT<P>
+impl<'a, P> FromSql<'a> for ewkb::GeometryT<P>
 where
     P: Point + EwkbRead,
 {
@@ -164,17 +196,21 @@ where
 
 // NOTE: Implement once per point type because AsEwkbPoint<'a> doesn't live long enough for ToSql
 macro_rules! impl_geometry_to_sql {
-    ($ptype:path) => (
+    ($ptype:path) => {
         impl ToSql for ewkb::GeometryT<$ptype> {
-            fn to_sql(&self, _: &Type, out: &mut Vec<u8>) -> Result<IsNull, Box<Error + Sync + Send>> {
-                self.as_ewkb().write_ewkb(out)?;
+            fn to_sql(
+                &self,
+                _: &Type,
+                out: &mut BytesMut,
+            ) -> Result<IsNull, Box<Error + Sync + Send>> {
+                self.as_ewkb().write_ewkb(&mut out.writer())?;
                 Ok(IsNull::No)
             }
 
             to_sql_checked!();
             accepts_geography!();
         }
-    )
+    };
 }
 
 impl_geometry_to_sql!(ewkb::Point);
@@ -182,7 +218,7 @@ impl_geometry_to_sql!(ewkb::PointZ);
 impl_geometry_to_sql!(ewkb::PointM);
 impl_geometry_to_sql!(ewkb::PointZM);
 
-impl<P> FromSql for ewkb::GeometryCollectionT<P>
+impl<'a, P> FromSql<'a> for ewkb::GeometryCollectionT<P>
 where
     P: Point + EwkbRead,
 {
@@ -199,8 +235,8 @@ impl<'a, P> ToSql for ewkb::GeometryCollectionT<P>
 where
     P: Point + EwkbRead,
 {
-    fn to_sql(&self, _: &Type, out: &mut Vec<u8>) -> Result<IsNull, Box<Error + Sync + Send>> {
-        self.as_ewkb().write_ewkb(out)?;
+    fn to_sql(&self, _: &Type, out: &mut BytesMut) -> Result<IsNull, Box<Error + Sync + Send>> {
+        self.as_ewkb().write_ewkb(&mut out.writer())?;
         Ok(IsNull::No)
     }
 
@@ -210,7 +246,7 @@ where
 
 // --- TWKB ---
 
-impl FromSql for twkb::Point {
+impl<'a> FromSql<'a> for twkb::Point {
     fn from_sql(ty: &Type, raw: &[u8]) -> Result<Self, Box<Error + Sync + Send>> {
         let mut rdr = Cursor::new(raw);
         twkb::Point::read_twkb(&mut rdr)
@@ -220,7 +256,7 @@ impl FromSql for twkb::Point {
     accepts!(BYTEA);
 }
 
-impl FromSql for twkb::LineString {
+impl<'a> FromSql<'a> for twkb::LineString {
     fn from_sql(ty: &Type, raw: &[u8]) -> Result<Self, Box<Error + Sync + Send>> {
         let mut rdr = Cursor::new(raw);
         twkb::LineString::read_twkb(&mut rdr)
@@ -230,7 +266,7 @@ impl FromSql for twkb::LineString {
     accepts!(BYTEA);
 }
 
-impl FromSql for twkb::Polygon {
+impl<'a> FromSql<'a> for twkb::Polygon {
     fn from_sql(ty: &Type, raw: &[u8]) -> Result<Self, Box<Error + Sync + Send>> {
         let mut rdr = Cursor::new(raw);
         twkb::Polygon::read_twkb(&mut rdr)
@@ -240,7 +276,7 @@ impl FromSql for twkb::Polygon {
     accepts!(BYTEA);
 }
 
-impl FromSql for twkb::MultiPoint {
+impl<'a> FromSql<'a> for twkb::MultiPoint {
     accepts!(BYTEA);
     fn from_sql(ty: &Type, raw: &[u8]) -> Result<Self, Box<Error + Sync + Send>> {
         let mut rdr = Cursor::new(raw);
@@ -249,7 +285,7 @@ impl FromSql for twkb::MultiPoint {
     }
 }
 
-impl FromSql for twkb::MultiLineString {
+impl<'a> FromSql<'a> for twkb::MultiLineString {
     fn from_sql(ty: &Type, raw: &[u8]) -> Result<Self, Box<Error + Sync + Send>> {
         let mut rdr = Cursor::new(raw);
         twkb::MultiLineString::read_twkb(&mut rdr)
@@ -259,7 +295,7 @@ impl FromSql for twkb::MultiLineString {
     accepts!(BYTEA);
 }
 
-impl FromSql for twkb::MultiPolygon {
+impl<'a> FromSql<'a> for twkb::MultiPolygon {
     fn from_sql(ty: &Type, raw: &[u8]) -> Result<Self, Box<Error + Sync + Send>> {
         let mut rdr = Cursor::new(raw);
         twkb::MultiPolygon::read_twkb(&mut rdr)
@@ -271,35 +307,36 @@ impl FromSql for twkb::MultiPolygon {
 
 #[cfg(test)]
 mod tests {
-    use postgres;
-    use postgres::Connection;
+    use crate::{
+        ewkb::{self, AsEwkbLineString, AsEwkbPoint},
+        twkb, types as postgis,
+    };
+    use postgres::{Client, NoTls};
     use std::env;
     use std::error::Error;
-    use types as postgis;
-    use ewkb::{self, AsEwkbLineString, AsEwkbPoint};
-    use twkb;
 
     macro_rules! or_panic {
-        ($e:expr) => (
+        ($e:expr) => {
             match $e {
                 Ok(ok) => ok,
-                Err(err) => panic!("{:#?}", err)
+                Err(err) => panic!("{:#?}", err),
             }
-        )
+        };
     }
 
-    fn connect() -> Connection {
+    fn connect() -> Client {
         match env::var("DBCONN") {
-            Result::Ok(val) => Connection::connect(&val as &str, postgres::TlsMode::None),
+            Result::Ok(val) => Client::connect(&val as &str, NoTls),
             Result::Err(err) => panic!("{:#?}", err),
-        }.unwrap()
+        }
+        .unwrap()
     }
 
     #[test]
     #[ignore]
     #[cfg_attr(rustfmt, rustfmt_skip)]
     fn test_insert_point() {
-        let conn = connect();
+        let mut conn = connect();
         or_panic!(conn.execute("CREATE TEMPORARY TABLE geomtests (geom geometry(Point))", &[]));
 
         // 'POINT (10 -20)'
@@ -316,7 +353,7 @@ mod tests {
         assert!(result.iter().map(|r| r.get::<_, bool>(0)).last().unwrap());
         or_panic!(conn.execute("TRUNCATE geomtests", &[]));
 
-        let conn = connect();
+        let mut conn = connect();
         or_panic!(conn.execute("CREATE TEMPORARY TABLE geomtests (geom geometry(Point, 4326))", &[]));
 
         let point = ewkb::Point { x: 10.0, y: -20.0, srid: Some(4326) };
@@ -335,7 +372,7 @@ mod tests {
     #[ignore]
     #[cfg_attr(rustfmt, rustfmt_skip)]
     fn test_insert_line() {
-        let conn = connect();
+        let mut conn = connect();
         or_panic!(conn.execute("CREATE TEMPORARY TABLE geomtests (geom geometry(LineString))", &[]));
 
         let p = |x, y| ewkb::Point { x: x, y: y, srid: None };
@@ -346,7 +383,7 @@ mod tests {
         assert!(result.iter().map(|r| r.get::<_, bool>(0)).last().unwrap());
         or_panic!(conn.execute("TRUNCATE geomtests", &[]));
 
-        let conn = connect();
+        let mut conn = connect();
         or_panic!(conn.execute("CREATE TEMPORARY TABLE geomtests (geom geometry(LineString, 4326))", &[]));
 
         // 'SRID=4326;LINESTRING (10 -20, -0 -0.5)'
@@ -356,7 +393,7 @@ mod tests {
         assert!(result.iter().map(|r| r.get::<_, bool>(0)).last().unwrap());
         or_panic!(conn.execute("TRUNCATE geomtests", &[]));
 
-        let conn = connect();
+        let mut conn = connect();
         or_panic!(conn.execute("CREATE TEMPORARY TABLE geomtests (geom geometry(LineStringZ, 4326))", &[]));
 
         let p = |x, y, z| ewkb::PointZ { x: x, y: y, z: z, srid: Some(4326) };
@@ -372,7 +409,7 @@ mod tests {
     #[ignore]
     #[cfg_attr(rustfmt, rustfmt_skip)]
     fn test_insert_polygon() {
-        let conn = connect();
+        let mut conn = connect();
         or_panic!(conn.execute("CREATE TEMPORARY TABLE geomtests (geom geometry(Polygon))", &[]));
         let p = |x, y| ewkb::Point { x: x, y: y, srid: Some(4326) };
         // SELECT 'SRID=4326;POLYGON ((0 0, 2 0, 2 2, 0 2, 0 0))'::geometry
@@ -387,7 +424,7 @@ mod tests {
     #[ignore]
     #[cfg_attr(rustfmt, rustfmt_skip)]
     fn test_insert_multipoint() {
-        let conn = connect();
+        let mut conn = connect();
         or_panic!(conn.execute("CREATE TEMPORARY TABLE geomtests (geom geometry(MultiPointZ))", &[]));
         let p = |x, y, z| ewkb::PointZ { x: x, y: y, z: z, srid: Some(4326) };
         // SELECT 'SRID=4326;MULTIPOINT ((10 -20 100), (0 -0.5 101))'::geometry
@@ -401,7 +438,7 @@ mod tests {
     #[ignore]
     #[cfg_attr(rustfmt, rustfmt_skip)]
     fn test_insert_multiline() {
-        let conn = connect();
+        let mut conn = connect();
         or_panic!(conn.execute("CREATE TEMPORARY TABLE geomtests (geom geometry(MultiLineString))", &[]));
         let p = |x, y| ewkb::Point { x: x, y: y, srid: Some(4326) };
         // SELECT 'SRID=4326;MULTILINESTRING ((10 -20, 0 -0.5), (0 0, 2 0))'::geometry
@@ -417,7 +454,7 @@ mod tests {
     #[ignore]
     #[cfg_attr(rustfmt, rustfmt_skip)]
     fn test_insert_multipolygon() {
-        let conn = connect();
+        let mut conn = connect();
         or_panic!(conn.execute("CREATE TEMPORARY TABLE geomtests (geom geometry(MultiPolygon))", &[]));
         let p = |x, y| ewkb::Point { x: x, y: y, srid: Some(4326) };
         // SELECT 'SRID=4326;MULTIPOLYGON (((0 0, 2 0, 2 2, 0 2, 0 0)), ((10 10, -2 10, -2 -2, 10 -2, 10 10)))'::geometry
@@ -435,7 +472,7 @@ mod tests {
     #[ignore]
     #[cfg_attr(rustfmt, rustfmt_skip)]
     fn test_insert_geometry() {
-        let conn = connect();
+        let mut conn = connect();
         or_panic!(conn.execute("CREATE TEMPORARY TABLE geomtests (geom geometry)", &[]));
         let p = |x, y| ewkb::Point { x: x, y: y, srid: Some(4326) };
         // SELECT 'SRID=4326;MULTIPOLYGON (((0 0, 2 0, 2 2, 0 2, 0 0)), ((10 10, -2 10, -2 -2, 10 -2, 10 10)))'::geometry
@@ -456,7 +493,7 @@ mod tests {
     #[ignore]
     #[cfg_attr(rustfmt, rustfmt_skip)]
     fn test_insert_geometrycollection() {
-        let conn = connect();
+        let mut conn = connect();
         or_panic!(conn.execute("CREATE TEMPORARY TABLE geomtests (geom geometry(GeometryCollection))", &[]));
         let p = |x, y| ewkb::Point { x: x, y: y, srid: Some(4326) };
         // SELECT 'SRID=4326;LINESTRING (10 -20, -0 -0.5)'
@@ -486,7 +523,7 @@ mod tests {
     #[ignore]
     #[cfg_attr(rustfmt, rustfmt_skip)]
     fn test_select_point() {
-        let conn = connect();
+        let mut conn = connect();
         let result = or_panic!(conn.query("SELECT ('POINT(10 -20)')::geometry", &[]));
         let point = result.iter().map(|r| r.get::<_, ewkb::Point>(0)).last().unwrap();
         assert_eq!(point, ewkb::Point { x: 10.0, y: -20.0, srid: None });
@@ -504,7 +541,7 @@ mod tests {
         assert_eq!(&format!("{:?}", point), "Point { x: NaN, y: NaN, srid: None }");
 
         let result = or_panic!(conn.query("SELECT NULL::geometry(Point)", &[]));
-        let point = result.iter().map(|r| r.get_opt::<_, ewkb::Point>(0)).last().unwrap();
+        let point = result.iter().map(|r| r.try_get::<_, ewkb::Point>(0)).last().unwrap();
         assert_eq!(&format!("{:?}", point), "Some(Err(Error(Conversion(WasNull))))");
     }
 
@@ -512,7 +549,7 @@ mod tests {
     #[ignore]
     #[cfg_attr(rustfmt, rustfmt_skip)]
     fn test_select_line() {
-        let conn = connect();
+        let mut conn = connect();
         let p = |x, y| ewkb::Point { x: x, y: y, srid: None };
         let result = or_panic!(conn.query("SELECT ('LINESTRING (10 -20, -0 -0.5)')::geometry", &[]));
         let line = result.iter().map(|r| r.get::<_, ewkb::LineString>(0)).last().unwrap();
@@ -532,7 +569,7 @@ mod tests {
     #[ignore]
     #[cfg_attr(rustfmt, rustfmt_skip)]
     fn test_select_polygon() {
-        let conn = connect();
+        let mut conn = connect();
         let result = or_panic!(conn.query("SELECT 'SRID=4326;POLYGON ((0 0, 2 0, 2 2, 0 2, 0 0))'::geometry", &[]));
         let poly = result.iter().map(|r| r.get::<_, ewkb::Polygon>(0)).last().unwrap();
         assert_eq!(format!("{:.0?}", poly), "PolygonT { rings: [LineStringT { points: [Point { x: 0, y: 0, srid: Some(4326) }, Point { x: 2, y: 0, srid: Some(4326) }, Point { x: 2, y: 2, srid: Some(4326) }, Point { x: 0, y: 2, srid: Some(4326) }, Point { x: 0, y: 0, srid: Some(4326) }], srid: Some(4326) }], srid: Some(4326) }");
@@ -542,7 +579,7 @@ mod tests {
     #[ignore]
     #[cfg_attr(rustfmt, rustfmt_skip)]
     fn test_select_multipoint() {
-        let conn = connect();
+        let mut conn = connect();
         let result = or_panic!(conn.query("SELECT 'SRID=4326;MULTIPOINT ((10 -20 100), (0 -0.5 101))'::geometry", &[]));
         let points = result.iter().map(|r| r.get::<_, ewkb::MultiPointZ>(0)).last().unwrap();
         assert_eq!(format!("{:.1?}", points), "MultiPointT { points: [PointZ { x: 10.0, y: -20.0, z: 100.0, srid: None }, PointZ { x: 0.0, y: -0.5, z: 101.0, srid: None }], srid: Some(4326) }");
@@ -552,7 +589,7 @@ mod tests {
     #[ignore]
     #[cfg_attr(rustfmt, rustfmt_skip)]
     fn test_select_multiline() {
-        let conn = connect();
+        let mut conn = connect();
         let result = or_panic!(conn.query("SELECT 'SRID=4326;MULTILINESTRING ((10 -20, 0 -0.5), (0 0, 2 0))'::geometry", &[]));
         let multiline = result.iter().map(|r| r.get::<_, ewkb::MultiLineString>(0)).last().unwrap();
         assert_eq!(format!("{:.1?}", multiline), "MultiLineStringT { lines: [LineStringT { points: [Point { x: 10.0, y: -20.0, srid: None }, Point { x: 0.0, y: -0.5, srid: None }], srid: None }, LineStringT { points: [Point { x: 0.0, y: 0.0, srid: None }, Point { x: 2.0, y: 0.0, srid: None }], srid: None }], srid: Some(4326) }");
@@ -562,7 +599,7 @@ mod tests {
     #[ignore]
     #[cfg_attr(rustfmt, rustfmt_skip)]
     fn test_select_multipolygon() {
-        let conn = connect();
+        let mut conn = connect();
         let result = or_panic!(conn.query("SELECT 'SRID=4326;MULTIPOLYGON (((0 0, 2 0, 2 2, 0 2, 0 0)), ((10 10, -2 10, -2 -2, 10 -2, 10 10)))'::geometry", &[]));
         let multipoly = result.iter().map(|r| r.get::<_, ewkb::MultiPolygon>(0)).last().unwrap();
         assert_eq!(format!("{:.0?}", multipoly), "MultiPolygonT { polygons: [PolygonT { rings: [LineStringT { points: [Point { x: 0, y: 0, srid: None }, Point { x: 2, y: 0, srid: None }, Point { x: 2, y: 2, srid: None }, Point { x: 0, y: 2, srid: None }, Point { x: 0, y: 0, srid: None }], srid: None }], srid: None }, PolygonT { rings: [LineStringT { points: [Point { x: 10, y: 10, srid: None }, Point { x: -2, y: 10, srid: None }, Point { x: -2, y: -2, srid: None }, Point { x: 10, y: -2, srid: None }, Point { x: 10, y: 10, srid: None }], srid: None }], srid: None }], srid: Some(4326) }");
@@ -572,7 +609,7 @@ mod tests {
     #[ignore]
     #[cfg_attr(rustfmt, rustfmt_skip)]
     fn test_select_geometrycollection() {
-        let conn = connect();
+        let mut conn = connect();
         let result = or_panic!(conn.query("SELECT 'GeometryCollection(POINT (10 10),POINT (30 30),LINESTRING (15 15, 20 20))'::geometry", &[]));
         let geom = result.iter().map(|r| r.get::<_, ewkb::GeometryCollection>(0)).last().unwrap();
         assert_eq!(format!("{:.0?}", geom), "GeometryCollectionT { geometries: [Point(Point { x: 10, y: 10, srid: None }), Point(Point { x: 30, y: 30, srid: None }), LineString(LineStringT { points: [Point { x: 15, y: 15, srid: None }, Point { x: 20, y: 20, srid: None }], srid: None })], srid: None }");
@@ -582,7 +619,7 @@ mod tests {
     #[ignore]
     #[cfg_attr(rustfmt, rustfmt_skip)]
     fn test_select_geometry() {
-        let conn = connect();
+        let mut conn = connect();
         or_panic!(conn.execute("CREATE TEMPORARY TABLE geomtests (geom geometry)", &[]));
         or_panic!(conn.execute("INSERT INTO geomtests VALUES('SRID=4326;POINT(10 -20 99)'::geometry)", &[]));
         let result = or_panic!(conn.query("SELECT geom FROM geomtests", &[]));
@@ -594,9 +631,9 @@ mod tests {
     #[ignore]
     #[cfg_attr(rustfmt, rustfmt_skip)]
     fn test_select_type_error() {
-        let conn = connect();
+        let mut conn = connect();
         let result = or_panic!(conn.query("SELECT ('LINESTRING (10 -20, -0 -0.5)')::geometry", &[]));
-        let poly = result.iter().map(|r| r.get_opt::<_, ewkb::Polygon>(0)).last().unwrap();
+        let poly = result.iter().map(|r| r.try_get::<_, ewkb::Polygon>(0)).last().unwrap();
         assert_eq!(format!("{:?}", poly), "Some(Err(Error(Conversion(StringError(\"cannot convert geometry to PolygonT\")))))");
     }
 
@@ -604,7 +641,7 @@ mod tests {
     #[ignore]
     #[cfg_attr(rustfmt, rustfmt_skip)]
     fn test_twkb() {
-        let conn = connect();
+        let mut conn = connect();
         let result = or_panic!(conn.query("SELECT ST_AsTWKB('POINT(10 -20)'::geometry)", &[]));
         let point = result.iter().map(|r| r.get::<_, twkb::Point>(0)).last().unwrap();
         assert_eq!(point, twkb::Point {x: 10.0, y: -20.0});
@@ -620,7 +657,7 @@ mod tests {
         assert!(point.x().is_nan());
 
         let result = or_panic!(conn.query("SELECT ST_AsTWKB(NULL::geometry(Point))", &[]));
-        let point = result.iter().map(|r| r.get_opt::<_, twkb::Point>(0)).last().unwrap();
+        let point = result.iter().map(|r| r.try_get::<_, twkb::Point>(0)).last().unwrap();
         assert_eq!(&format!("{:?}", point), "Some(Err(Error(Conversion(WasNull))))");
 
         let result = or_panic!(conn.query("SELECT ST_AsTWKB('LINESTRING (10 -20, -0 -0.5)'::geometry, 1)", &[]));
@@ -632,7 +669,7 @@ mod tests {
     #[ignore]
     #[cfg_attr(rustfmt, rustfmt_skip)]
     fn test_twkb_insert() {
-        let conn = connect();
+        let mut conn = connect();
         or_panic!(conn.execute("CREATE TEMPORARY TABLE geomtests (geom geometry(Point))", &[]));
 
         let result = or_panic!(conn.query("SELECT ST_AsTWKB('POINT(10 -20)'::geometry)", &[]));
@@ -643,7 +680,7 @@ mod tests {
         assert!(result.iter().map(|r| r.get::<_, bool>(0)).last().unwrap());
         or_panic!(conn.execute("TRUNCATE geomtests", &[]));
 
-        let conn = connect();
+        let mut conn = connect();
         or_panic!(conn.execute("CREATE TEMPORARY TABLE geomtests (geom geometry(LineString))", &[]));
 
         let result = or_panic!(conn.query("SELECT ST_AsTWKB('LINESTRING (10 -20, -0 -0.5)'::geometry, 1)", &[]));
@@ -660,16 +697,18 @@ mod tests {
     #[cfg_attr(rustfmt, rustfmt_skip)]
     #[allow(unused_imports,unused_variables)]
     fn test_examples() {
-        use postgres::{Connection, TlsMode};
+        use postgres::{Client, NoTls};
         //use postgis::ewkb;
         //use postgis::LineString;
 
         fn main() {
             //
-            use ewkb;
-            use types::LineString;
-            use twkb;
-            let conn = connect();
+            use crate::{
+                ewkb,
+                types::LineString,
+                twkb
+            };
+            let mut conn = connect();
             or_panic!(conn.execute("CREATE TEMPORARY TABLE busline (route geometry(LineString))", &[]));
             or_panic!(conn.execute("CREATE TEMPORARY TABLE stops (stop geometry(Point))", &[]));
             or_panic!(conn.execute("INSERT INTO busline (route) VALUES ('LINESTRING(10 -20, -0 -0.5)'::geometry)", &[]));
@@ -683,8 +722,8 @@ mod tests {
             }
 
             for row in &conn.query("SELECT * FROM busline", &[]).unwrap() {
-                let route = row.get_opt::<_, Option<ewkb::LineString>>("route");
-                match route.unwrap() {
+                let route = row.try_get::<_, Option<ewkb::LineString>>("route");
+                match route {
                     Ok(Some(geom)) => { println!("{:?}", geom) }
                     Ok(None) => { /* Handle NULL value */ }
                     Err(err) => { println!("Error: {}", err) }

--- a/src/postgis.rs
+++ b/src/postgis.rs
@@ -313,7 +313,6 @@ mod tests {
     };
     use postgres::{Client, NoTls};
     use std::env;
-    use std::error::Error;
 
     macro_rules! or_panic {
         ($e:expr) => {
@@ -379,7 +378,7 @@ mod tests {
         // 'LINESTRING (10 -20, -0 -0.5)'
         let line = ewkb::LineString {srid: None, points: vec![p(10.0, -20.0), p(0., -0.5)]};
         or_panic!(client.execute("INSERT INTO geomtests (geom) VALUES ($1)", &[&line]));
-        let result = or_panic!(client.query("SELECT geom=ST_GeomFromEWKT('LINESTRING(10 -20, -0 -0.5)') FROM geomtests", &[]));
+        let result = or_panic!(client.query("SELECT geom=ST_GeomFromEWKT('LINESTRING(10 -20, 0 -0.5)') FROM geomtests", &[]));
         assert!(result.iter().map(|r| r.get::<_, bool>(0)).last().unwrap());
         or_panic!(client.execute("TRUNCATE geomtests", &[]));
 
@@ -389,7 +388,7 @@ mod tests {
         // 'SRID=4326;LINESTRING (10 -20, -0 -0.5)'
         let line = ewkb::LineString {srid: Some(4326), points: vec![p(10.0, -20.0), p(0., -0.5)]};
         or_panic!(client.execute("INSERT INTO geomtests (geom) VALUES ($1)", &[&line]));
-        let result = or_panic!(client.query("SELECT geom=ST_GeomFromEWKT('SRID=4326;LINESTRING(10 -20, -0 -0.5)') FROM geomtests", &[]));
+        let result = or_panic!(client.query("SELECT geom=ST_GeomFromEWKT('SRID=4326;LINESTRING(10 -20, 0 -0.5)') FROM geomtests", &[]));
         assert!(result.iter().map(|r| r.get::<_, bool>(0)).last().unwrap());
         or_panic!(client.execute("TRUNCATE geomtests", &[]));
 
@@ -400,7 +399,7 @@ mod tests {
         // 'SRID=4326;LINESTRING (10 -20 100, -0 -0.5 101)'
         let line = ewkb::LineStringZ {srid: Some(4326), points: vec![p(10.0, -20.0, 100.0), p(0., -0.5, 101.0)]};
         or_panic!(client.execute("INSERT INTO geomtests (geom) VALUES ($1)", &[&line]));
-        let result = or_panic!(client.query("SELECT geom=ST_GeomFromEWKT('SRID=4326;LINESTRING (10 -20 100, -0 -0.5 101)') FROM geomtests", &[]));
+        let result = or_panic!(client.query("SELECT geom=ST_GeomFromEWKT('SRID=4326;LINESTRING (10 -20 100, 0 -0.5 101)') FROM geomtests", &[]));
         assert!(result.iter().map(|r| r.get::<_, bool>(0)).last().unwrap());
         or_panic!(client.execute("TRUNCATE geomtests", &[]));
     }
@@ -683,11 +682,11 @@ mod tests {
         let mut client = connect();
         or_panic!(client.execute("CREATE TEMPORARY TABLE geomtests (geom geometry(LineString))", &[]));
 
-        let result = or_panic!(client.query("SELECT ST_AsTWKB('LINESTRING (10 -20, -0 -0.5)'::geometry, 1)", &[]));
+        let result = or_panic!(client.query("SELECT ST_AsTWKB('LINESTRING (10 -20, 0 -0.5)'::geometry, 1)", &[]));
         let line = result.iter().map(|r| r.get::<_, twkb::LineString>(0)).last().unwrap();
 
         or_panic!(client.execute("INSERT INTO geomtests (geom) VALUES ($1)", &[&line.as_ewkb()]));
-        let result = or_panic!(client.query("SELECT geom=ST_GeomFromEWKT('LINESTRING (10 -20, -0 -0.5)') FROM geomtests", &[]));
+        let result = or_panic!(client.query("SELECT geom=ST_GeomFromEWKT('LINESTRING (10 -20, 0 -0.5)') FROM geomtests", &[]));
         assert!(result.iter().map(|r| r.get::<_, bool>(0)).last().unwrap());
         or_panic!(client.execute("TRUNCATE geomtests", &[]));
     }

--- a/src/twkb.rs
+++ b/src/twkb.rs
@@ -16,16 +16,14 @@
 //! }
 //! ```
 
-use types as postgis;
-use ewkb;
+use crate::{error::Error, ewkb, types as postgis};
+use byteorder::ReadBytesExt;
+use std::f64;
+use std::fmt;
 use std::io::prelude::*;
 use std::mem;
-use std::fmt;
-use std::u8;
-use std::f64;
 use std::slice::Iter;
-use byteorder::ReadBytesExt;
-use error::Error;
+use std::u8;
 
 #[derive(PartialEq, Clone, Debug)]
 pub struct Point {
@@ -571,8 +569,10 @@ impl<'a> ewkb::AsEwkbMultiPolygon<'a> for MultiPolygon {
 }
 
 #[cfg(test)]
-use ewkb::{AsEwkbLineString, AsEwkbMultiLineString, AsEwkbMultiPoint, AsEwkbMultiPolygon,
-           AsEwkbPoint, AsEwkbPolygon, EwkbWrite};
+use ewkb::{
+    AsEwkbLineString, AsEwkbMultiLineString, AsEwkbMultiPoint, AsEwkbMultiPolygon, AsEwkbPoint,
+    AsEwkbPolygon, EwkbWrite,
+};
 
 #[cfg(test)]
 #[cfg_attr(rustfmt, rustfmt_skip)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -2,7 +2,7 @@
 // Copyright (c) Pirmin Kalberer. All rights reserved.
 //
 
-pub trait Point {
+pub trait Point: Send + Sync {
     fn x(&self) -> f64;
     fn y(&self) -> f64;
     fn opt_z(&self) -> Option<f64> {
@@ -13,37 +13,37 @@ pub trait Point {
     }
 }
 
-pub trait LineString<'a> {
+pub trait LineString<'a>: Send + Sync {
     type ItemType: 'a + Point;
     type Iter: Iterator<Item = &'a Self::ItemType>;
     fn points(&'a self) -> Self::Iter;
 }
 
-pub trait Polygon<'a> {
+pub trait Polygon<'a>: Send + Sync {
     type ItemType: 'a + LineString<'a>;
     type Iter: Iterator<Item = &'a Self::ItemType>;
     fn rings(&'a self) -> Self::Iter;
 }
 
-pub trait MultiPoint<'a> {
+pub trait MultiPoint<'a>: Send + Sync {
     type ItemType: 'a + Point;
     type Iter: Iterator<Item = &'a Self::ItemType>;
     fn points(&'a self) -> Self::Iter;
 }
 
-pub trait MultiLineString<'a> {
+pub trait MultiLineString<'a>: Send + Sync {
     type ItemType: 'a + LineString<'a>;
     type Iter: Iterator<Item = &'a Self::ItemType>;
     fn lines(&'a self) -> Self::Iter;
 }
 
-pub trait MultiPolygon<'a> {
+pub trait MultiPolygon<'a>: Send + Sync {
     type ItemType: 'a + Polygon<'a>;
     type Iter: Iterator<Item = &'a Self::ItemType>;
     fn polygons(&'a self) -> Self::Iter;
 }
 
-pub trait Geometry<'a> {
+pub trait Geometry<'a>: Send + Sync {
     type Point: 'a + Point;
     type LineString: 'a + LineString<'a>;
     type Polygon: 'a + Polygon<'a>;


### PR DESCRIPTION
This PR performs a few modernization steps to get the package working with a modern Rust / `rust-postgres` setup:

* Updates the postgres dependency to `0.17`.
* Updates Rust edition to 2018 and fixes import handling.
* Runs `cargo fmt`.
* Updates some tests that failed with some signed-zero-related issues; these failed for me prior to making any changes as well, so I'm not sure when this regression / functionality change occurred. The tests pass now, but it's possible the original intention of the test is no longer supported.