### PR TITLE
Optimize dependencies by using `postgres_types`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,9 @@ license = "MIT"
 edition = "2018"
 
 [dependencies]
-postgres = "^0.17"
 byteorder = "^0.5"
+postgres-types = "0.1"
 bytes = "0.5"
+
+[dev-dependencies]
+postgres = "^0.17"

--- a/src/postgis.rs
+++ b/src/postgis.rs
@@ -11,7 +11,7 @@ use crate::{
     types::{LineString, Point, Polygon},
 };
 use bytes::{buf::ext::BufMutExt, BytesMut};
-use postgres::types::{accepts, to_sql_checked, FromSql, IsNull, ToSql, Type};
+use postgres_types::{accepts, to_sql_checked, FromSql, IsNull, ToSql, Type};
 use std::error::Error;
 use std::io::Cursor;
 


### PR DESCRIPTION
### Motivation
By adding the `postgres` dependency, additional crates are pulled which are not required (in total 97). However, only postgres types are used by the library. Instead of pulling the large dependency `postgres`, only pull the used subset. Postgres provides a crate for this use case. This cuts the dependencies pulled in half (in total 45). Postgres is only required for the tests.

#### Update Dependencies
In order to be compatiable with future releases of the `postgres` crate, a new version of `rust-postgis` with updated depedencies must be provided. Using `postgres_types` allows  `rust-postgis` to be compatible with different versions of the `postgres` crate (assuming that the `postgres` crate uses a compatible `postgres_types` crate).

### Conclusion
- hopefully less dependency updates
- less dependencies to pull, thus faster compile times (on my machine from 11.20s to 3.26s)